### PR TITLE
Update GitHub link

### DIFF
--- a/content/settings.json
+++ b/content/settings.json
@@ -8,6 +8,6 @@
     "light": "/Sigstore-logo_horizontal-color.svg",
     "dark": "/Sigstore-logo_horizontal-white.svg"
   },
-  "github": "sigstore/sigstore-website",
+  "github": "sigstore/docs",
   "twitter": "@projectsigstore"
 }


### PR DESCRIPTION
Updating the frontend GitHub link to point to sigstore/docs rather than sigstore/sigstore-website

Signed-off-by: Lisa Tagliaferri
