### PR TITLE
Adds Import Key Pair Docs

### DIFF
--- a/content/en/cosign/import-keypair.md
+++ b/content/en/cosign/import-keypair.md
@@ -1,0 +1,30 @@
+---
+title: "Importing Key Pairs"
+category: "Cosign"
+position: 104
+---
+
+> Currently only supports RSA and ECDSA private keys
+
+### Import a Key Pair
+
+The importing of a key pair with `cosign` is as follows.
+
+```shell
+$ cosign import-key-pair --key opensslrsakey.pem
+Enter password for private key:
+Enter password for private key again:
+Private key written to import-cosign.key
+Public key written to import-cosign.pub
+```
+
+### Sign a container with imported keypair
+
+The use of the imported key pair to sign an artifact with `cosign` is as follows.
+
+```shell
+$ cosign sign --key import-cosign.key $IMAGE_DIGEST
+Enter password for private key:
+tlog entry created with index: *****
+Pushing signature to: *****
+```

--- a/content/en/cosign/sign.md
+++ b/content/en/cosign/sign.md
@@ -1,7 +1,7 @@
 ---
 title: "Signing"
 category: "Cosign"
-position: 104
+position: 105
 ---
 
 The general signing format with the `cosign sign` command is as follows.

--- a/content/en/cosign/verify.md
+++ b/content/en/cosign/verify.md
@@ -1,7 +1,7 @@
 ---
 title: "Verifying Claims"
 category: "Cosign"
-position: 105
+position: 106
 ---
 
 The general verification format with the `cosign verify` command is as follows.


### PR DESCRIPTION
- adds import key pair docs
- amends position of sign and verify pages so that import key pair and generate key pair are next to each other in menu bar

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>

Closes: https://github.com/sigstore/cosign/issues/822