### PR TITLE
fix minor typos/styling in policy-controller overview

### DIFF
--- a/content/en/policy-controller/overview.md
+++ b/content/en/policy-controller/overview.md
@@ -77,7 +77,7 @@ Glob uses golang [filepath](https://pkg.go.dev/path/filepath#Match) semantics fo
 matching the images against. Additionally you can specify a more traditional
 `**` to match any number of characters. Furthermore to make it easier to specify
  images, there are few defaults when an image is matched, namely:
- * If there is no host in the glob pattern `index.docker.io` is used for the host. This allows users to specify commonly found images from Docker simply as myproject/nginx instead of inded.docker.io/myproject/nginx
+ * If there is no host in the glob pattern `index.docker.io` is used for the host. This allows users to specify commonly found images from Docker simply as `myproject/nginx` instead of `index.docker.io/myproject/nginx`
  * If the image is specified without multiple path elements (so not separated by `/`), then `library` is defaulted. For example specifying `busybox` will result in library/busybox. And combined with above, will result in match being made against `index.docker.io/library/busybox`.
 
 A sample of a `ClusterImagePolicy` which matches against all images using glob:
@@ -223,7 +223,7 @@ spec:
 ### Configure `SignaturePullSecrets`
 
 If the signatures/attestations are in a different repo or they use different
-PullSecrets, you can configure `source` to point to a `secret` which must live
+`imagePullSecrets`, you can configure `source` to point to a `secret` which must live
 in the namespace where the pods are getting deployed.
 
 ```yaml


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fix minor typo's and styling in `policy-controller` overview.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Fix minor typo's and styling in `policy-controller` overview.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

This is a documentation change :D