### PR TITLE
Identities is required field, so state it.

### DIFF
--- a/content/en/policy-controller/overview.md
+++ b/content/en/policy-controller/overview.md
@@ -159,11 +159,11 @@ Each `keyless` authority can contain these properties:
 - `keyless.ca-cert`: specifies `ca-cert` information for the `keyless` authority
   - `secretRef.name`: specifies the secret location name in the same namespace where `policy-controller` is installed. <br/>The first key value will be used in the secret for the `ca-cert`.
   - `data`: specifies the inline certificate data
-- `keyless.identities`: Identity may contain an array of `issuer` and/or the `subject` found in the transparency log. There are
+- `keyless.identities`: Identities must contain an array of `issuer` and the `subject` matching the certificate used to sign. There are
 variant fields `issuerRegExp` and `subjectRegExp` which support
 regular expressions.
-  - `issuer`: specifies the issuer found in the transparency log. Regex patterns are supported through the `issuerRegExp` key.
-  - `subject`: specifies the subject found in the transparency log. Regex patterns are supported through the `subjectRegExp` key.
+  - `issuer`: specifies the issuer certificate was issued by. Regex patterns are supported through the `issuerRegExp` key.
+  - `subject`: specifies the subject certificate was issued to. Regex patterns are supported through the `subjectRegExp` key.
 
 ### Configuring `static` authorities
 
@@ -377,6 +377,9 @@ spec:
   - name: keylessatt
     keyless:
       url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
identities is now a required field, so update the wording as well as update the example that was missing it still.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->