### PR TITLE
Fix ORAS section

### DIFF
--- a/content/en/cosign/other_types.md
+++ b/content/en/cosign/other_types.md
@@ -90,7 +90,7 @@ Pushing signature to: us.gcr.io/user-vmtest2/wasm:sha256-9e7a511fb3130ee4641baf1
 
 ## OCI artifacts
 
-Push an artifact to a registry using [oras](https://github.com/deislabs/oras) (in this case, `cosign` itself):
+Push an artifact to a registry using [ORAS](https://oras.land/cli) (in this case, `cosign` itself):
 
 ```shell
 $ oras push us-central1-docker.pkg.dev/user-vmtest2/test/artifact ./cosign
@@ -119,6 +119,7 @@ The following checks were performed on each of these signatures:
   - Any certificates were verified against the Fulcio roots.
 
 {"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:551e6cce7ed2e5c914998f931b277bc879e675b74843e6f29bc17f3b5f692bef"},"Type":"cosign container image signature"},"Optional":null}
+```
 
 ## Tag signing
 


### PR DESCRIPTION
Signed-off-by: Mathieu Benoit <mathieu-benoit@hotmail.fr>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

ORAS has now its official website and is not anymore under the `deislabs` org, fixing the URL. Furthermore, fixing the closing code snippet section between `OCI artifacts` and `Tag signing`. Both fixes made on this page: https://docs.sigstore.dev/cosign/other_types/#oci-artifacts

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->