### PR TITLE
enforce usage of RFC3986 predicate types

### DIFF
--- a/content/en/cosign/attestation.md
+++ b/content/en/cosign/attestation.md
@@ -66,7 +66,7 @@ The following checks were performed on each of these signatures:
   - Any certificates were verified against the Fulcio roots.
 {
   "_type": "https://in-toto.io/Statement/v0.1",
-  "predicateType": "cosign.sigstore.dev/attestation/v1",
+  "predicateType": "https://cosign.sigstore.dev/attestation/v1",
   "subject": [
     {
       "name": "gcr.io/rekor-testing/distroless",
@@ -87,7 +87,7 @@ import "time"
 before: time.Parse(time.RFC3339, "2021-10-09T17:10:27Z")
 
 // The predicateType field must match this string
-predicateType: "cosign.sigstore.dev/attestation/v1"
+predicateType: "https://cosign.sigstore.dev/attestation/v1"
 
 // The predicate must match the following constraints.
 predicate: {
@@ -123,7 +123,7 @@ The following checks were performed on each of these signatures:
   - Any certificates were verified against the Fulcio roots.
 {
   "_type": "https://in-toto.io/Statement/v0.1",
-  "predicateType": "cosign.sigstore.dev/attestation/v1",
+  "predicateType": "https://cosign.sigstore.dev/attestation/v1",
   "subject": [
     {
       "name": "gcr.io/rekor-testing/distroless",

--- a/content/en/policy-controller/overview.md
+++ b/content/en/policy-controller/overview.md
@@ -291,12 +291,12 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: https://cosign.sigstore.dev/attestation/v1
       policy:
         type: cue
         data: |
-          predicateType: "cosign.sigstore.dev/attestation/v1"
-          predicate: Data: "foobar e2e test"
+          predicateType: "https://cosign.sigstore.dev/attestation/v1"
+          predicate: "foobar e2e test"
 ```
 
 `policy` is optional and if left out, only the existence of the attestation is
@@ -322,15 +322,15 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: https://cosign.sigstore.dev/attestation/v1
       policy:
         type: rego
         data: |
           package sigstore
           default isCompliant = false
           isCompliant {
-            input.predicateType == "cosign.sigstore.dev/attestation/v1"
-            input.predicate.Data == "foobar e2e test"
+            input.predicateType == "https://cosign.sigstore.dev/attestation/v1"
+            input.predicate == "foobar e2e test"
           }
 ```
 
@@ -383,19 +383,19 @@ spec:
     ctlog:
       url: http://rekor.rekor-system.svc
     attestations:
-    - predicateType: custom
+    - predicateType: https://cosign.sigstore.dev/attestation/v1
       name: customkeyless
       policy:
         type: cue
         data: |
           import "time"
           before: time.Parse(time.RFC3339, "2049-10-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/v1"
           predicate: {
-            Data: "foobar e2e test"
+            foo: "foobar e2e test"
             Timestamp: <before
           }
-    - predicateType: vuln
+    - predicateType: https://cosign.sigstore.dev/attestation/vuln/v1
       name: vulnkeyless
       policy:
         type: cue
@@ -403,7 +403,7 @@ spec:
           import "time"
           before: time.Parse(time.RFC3339, "2022-04-15T17:10:27Z")
           after: time.Parse(time.RFC3339, "2022-03-09T17:10:27Z")
-          predicateType: "cosign.sigstore.dev/attestation/vuln/v1"
+          predicateType: "https://cosign.sigstore.dev/attestation/vuln/v1"
           predicate: {
             invocation: {
               uri: "invocation.example.com/cosign-testing"
@@ -429,12 +429,12 @@ spec:
       url: http://rekor.rekor-system.svc
     attestations:
     - name: custom-match-predicate
-      predicateType: custom
+      predicateType: https://cosign.sigstore.dev/attestation/v1
       policy:
         type: cue
         data: |
-          predicateType: "cosign.sigstore.dev/attestation/v1"
-          predicate: Data: "foobar key e2e test"
+          predicateType: "https://cosign.sigstore.dev/attestation/v1"
+          predicate: "foobar key e2e test"
   - name: keylesssignature
     keyless:
       url: http://fulcio.fulcio-system.svc

--- a/content/en/policy-controller/sample-policies.md
+++ b/content/en/policy-controller/sample-policies.md
@@ -29,7 +29,7 @@ spec:
         -----END PUBLIC KEY-----
     attestations:
     - name: must-have-spdxjson
-      predicateType: spdxjson
+      predicateType: https://spdx.dev/Document
       policy:
         type: cue
         data: |
@@ -46,12 +46,12 @@ Use the tool of your choice to generate an [SPDX](https://spdx.dev/) SBOM.
 
 For example purposes, you can use [`sboms/example.spdx.json`](https://github.com/sigstore/policy-controller/blob/main/examples/sboms/example.spdx.json).
 
-Then attach the SBOM to your image using [`cosign attest`](https://github.com/sigstore/cosign/blob/main/doc/cosign_attest.md) with the flag `--type spdxjson`, and signing it with a private key (for example, one located in a `keys` directory as in `keys/cosign.key`). You can review this in our [examples directory](https://github.com/sigstore/policy-controller/tree/main/examples).
+Then attach the SBOM to your image using [`cosign attest`](https://github.com/sigstore/cosign/blob/main/doc/cosign_attest.md) with the flag `--type 'https://spdx.dev/Document'`, and signing it with a private key (for example, one located in a `keys` directory as in `keys/cosign.key`). You can review this in our [examples directory](https://github.com/sigstore/policy-controller/tree/main/examples).
 
 ```
 export COSIGN_PASSWORD=""
 
-cosign attest --yes --type spdxjson \
+cosign attest --yes --type https://spdx.dev/Document \
   --predicate sboms/example.spdx.json \
   --key keys/cosign.key \
   "${IMAGE}"
@@ -77,7 +77,7 @@ spec:
       url: "https://fulcio.sigstore.dev"
     attestations:
     - name: must-have-spdxjson
-      predicateType: spdxjson
+      predicateType: https://spdx.dev/Document
       policy:
         type: cue
         data: |
@@ -94,12 +94,12 @@ Use the tool of your choice to generate an [SPDX](https://spdx.dev/) SBOM.
 
 For example purposes, you can use [`sboms/example.spdx.json`](https://github.com/sigstore/policy-controller/blob/main/examples/sboms/example.spdx.json).
 
-Then attach the SBOM to your image using [`cosign attest`](https://github.com/sigstore/cosign/blob/main/doc/cosign_attest.md) along with the flag `--type spdxjson`, signing keylessly against the public Fulcio root:
+Then attach the SBOM to your image using [`cosign attest`](https://github.com/sigstore/cosign/blob/main/doc/cosign_attest.md) along with the flag `--type 'https://spdx.dev/Document'`, signing keylessly against the public Fulcio root:
 
 ```
 export COSIGN_EXPERIMENTAL=1
 
-cosign attest --yes --type spdxjson \
+cosign attest --yes --type https://spdx.dev/Document \
   --predicate sboms/example.spdx.json \
   "${IMAGE}"
 ```


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Enforce the usage of RFC3986 predicate types when verifying an attestation.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Use RFC3986 predicate types
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->