### PR TITLE
Update sigstore build

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ yarn install
 ```bash
 yarn dev
 ```
+**Note:** If the error "digital envelope routines::unsupported" appears and the build fails, correct this by enabling the legacy OpenSSL provider.
+
+On Unix-like, enter the command:
+
+```bash
+export NODE_OPTIONS=--openssl-legacy-provider
+```
 
 ## Static Generation
 

--- a/content/en/cosign/installation.md
+++ b/content/en/cosign/installation.md
@@ -4,7 +4,7 @@ category: "Cosign"
 position: 102
 ---
 
-## With Go 1.19+
+## With Go 1.19+  Download the cosign binary first THEN install with GO
 
 If you have Go 1.19+, you can directly install Cosign by running:
 

--- a/content/en/cosign/installation.md
+++ b/content/en/cosign/installation.md
@@ -6,7 +6,7 @@ position: 102
 
 ## With Go 1.19+ 
 
-If you have Go 1.19+, you can directly install Cosign by downloading the cosign binary and running:
+If you have Go 1.19+, you can directly install Cosign by downloading the Cosign binary and running:
 
 ```console
 go install github.com/sigstore/cosign/v2/cmd/cosign@latest

--- a/content/en/cosign/installation.md
+++ b/content/en/cosign/installation.md
@@ -4,9 +4,9 @@ category: "Cosign"
 position: 102
 ---
 
-## With Go 1.19+  Download the cosign binary first THEN install with GO
+## With Go 1.19+ 
 
-If you have Go 1.19+, you can directly install Cosign by running:
+If you have Go 1.19+, you can directly install Cosign by downloading the cosign binary and running:
 
 ```console
 go install github.com/sigstore/cosign/v2/cmd/cosign@latest

--- a/content/en/cosign/kubernetes.md
+++ b/content/en/cosign/kubernetes.md
@@ -4,7 +4,7 @@ category: "Cosign"
 position: 102
 ---
 
-## Kubernetes Secrets  remove this page
+## Kubernetes Secrets
 
 Cosign can use keys stored in Kubernetes Secrets to sign and verify signatures.
 In order to generate a secret, pass a `k8s://[NAMESPACE]/[NAME]` URI specifying the namespace and secret name to `cosign generate-key-pair` as follows.

--- a/content/en/cosign/kubernetes.md
+++ b/content/en/cosign/kubernetes.md
@@ -4,7 +4,7 @@ category: "Cosign"
 position: 102
 ---
 
-## Kubernetes Secrets
+## Kubernetes Secrets  remove this page
 
 Cosign can use keys stored in Kubernetes Secrets to sign and verify signatures.
 In order to generate a secret, pass a `k8s://[NAMESPACE]/[NAME]` URI specifying the namespace and secret name to `cosign generate-key-pair` as follows.

--- a/content/en/cosign/working_with_blobs.md
+++ b/content/en/cosign/working_with_blobs.md
@@ -40,45 +40,8 @@ cosign sign --key cosign.key gcr.io/user-vmtest2/artifact
 Enter password for private key:
 Pushing signature to: gcr.io/user-vmtest2/artifact:sha256-3f612a4520b2c245d620d0cca029f1173f6bea76819dde8543f5b799ea3c696c.sig
 ```
-### sget  remove this section
-
-We also include the `sget` command for safer, automatic verification of signatures and integration with our binary transparency log, Rekor.
-
-To install `sget`, if you have Go 1.16+, you can directly run:
-
-    $ go install github.com/sigstore/cosign/cmd/sget@latest
-
-and the resulting binary will be placed at `$GOPATH/bin/sget` (or `$GOBIN/sget`, if set).
-
-Just like `curl`, `sget` can be used to fetch artifacts by digest using the OCI URL.
-Digest verification is automatic:
-
-```shell
-$ sget us.gcr.io/user-vmtest2/readme@sha256:4aa3054270f7a70b4528f2064ee90961788e1e1518703592ae4463de3b889dec > artifact
-```
-
-You can also use `sget` to fetch contents by tag.
-Fetching contents without verifying them is dangerous, so we require the artifact be signed in this case:
-
-```shell
-$ sget gcr.io/user-vmtest2/artifact
-error: public key must be specified when fetching by tag, you must fetch by digest or supply a public key
-
-$ sget --key cosign.pub us.gcr.io/user-vmtest2/readme > foo
-
-Verification for us.gcr.io/user-vmtest2/readme --
-The following checks were performed on each of these signatures:
-  - The cosign claims were validated
-  - Existence of the claims in the transparency log was verified offline
-  - The signatures were verified against the specified public key
-  - Any certificates were verified against the Fulcio roots.
-```
-
-The signature, claims and transparency log proofs are all verified automatically by sget as part of the download.
-
-`curl | bash` isn't a great idea, but `sget | bash` is less-bad.
-
-## Signing blobs as files  needs updating
+]
+## Signing blobs as files
 
 The `cosign sign-blob` and `cosign verify-blob` commands can be used to sign and verify standard files, in the absence of a registry.
 

--- a/content/en/cosign/working_with_blobs.md
+++ b/content/en/cosign/working_with_blobs.md
@@ -40,7 +40,7 @@ cosign sign --key cosign.key gcr.io/user-vmtest2/artifact
 Enter password for private key:
 Pushing signature to: gcr.io/user-vmtest2/artifact:sha256-3f612a4520b2c245d620d0cca029f1173f6bea76819dde8543f5b799ea3c696c.sig
 ```
-### sget
+### sget  remove this section
 
 We also include the `sget` command for safer, automatic verification of signatures and integration with our binary transparency log, Rekor.
 
@@ -78,7 +78,7 @@ The signature, claims and transparency log proofs are all verified automatically
 
 `curl | bash` isn't a great idea, but `sget | bash` is less-bad.
 
-## Signing blobs as files
+## Signing blobs as files  needs updating
 
 The `cosign sign-blob` and `cosign verify-blob` commands can be used to sign and verify standard files, in the absence of a registry.
 

--- a/content/en/cosign/working_with_blobs.md
+++ b/content/en/cosign/working_with_blobs.md
@@ -40,7 +40,7 @@ cosign sign --key cosign.key gcr.io/user-vmtest2/artifact
 Enter password for private key:
 Pushing signature to: gcr.io/user-vmtest2/artifact:sha256-3f612a4520b2c245d620d0cca029f1173f6bea76819dde8543f5b799ea3c696c.sig
 ```
-]
+
 ## Signing blobs as files
 
 The `cosign sign-blob` and `cosign verify-blob` commands can be used to sign and verify standard files, in the absence of a registry.

--- a/content/en/history.md
+++ b/content/en/history.md
@@ -5,7 +5,7 @@ category: 'About sigstore'
 position: 4
 ---
 
-The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. October, 2022, Sigstore was marked publicly available for announced general availability for rekor and fulcio https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d/
+The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. On October 25, 2022, Sigstore was marked publicly available as it announced [general availability for Rekor and Fulcio](https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d/).
 
 ## Relevant Research
 

--- a/content/en/history.md
+++ b/content/en/history.md
@@ -5,9 +5,7 @@ category: 'About sigstore'
 position: 4
 ---
 
-Over 100 contributors have pushed over 2,800 commits to Sigstore since its founding. Contributors to the project represent over 20 different organizations, including Red Hat, Google, Chainguard, Purdue University, VMware, Twitter, Citi, Charm, Anchore, and Iron Bank. Today, Sigstore Cosign has over 2,300 GitHub Stars and Sigstore Rekor has more than 3 million log entries. Today, there are over 1,200 active members on the [public Slack channel](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ), and many contributors and end users regularly attend Sigstore community meetings.
-
-The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. On July 28, 2021, the 1.0 version of Cosign was released, and the community is currently planning a general availability of Sigstore. 
+The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. October, 2022, Sigstore was marked publicaly available for announced general avail for rekor and fulcio https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d/
 
 ## Relevant Research
 

--- a/content/en/history.md
+++ b/content/en/history.md
@@ -44,4 +44,4 @@ As a living open source project with an engaged community, there are a number of
     * [Policy Controller repository](https://github.com/sigstore/policy-controller)
 * [Sigstore YouTube Channel](https://www.youtube.com/channel/UCWPVc8glVGOODxsA_ep0VVws)
 * [Sigstore Blog](https://blog.sigstore.dev/) 
-* [Sigstore Slack](https://join.slack.com/t/sigstore/shared_invite/zt-mhs55zh0-XmY3bcfWn4XEyMqUUutbUQ)
+* [Sigstore Slack](https://links.sigstore.dev/slack-invite)

--- a/content/en/history.md
+++ b/content/en/history.md
@@ -5,7 +5,7 @@ category: 'About sigstore'
 position: 4
 ---
 
-The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. October, 2022, Sigstore was marked publicaly available for announced general avail for rekor and fulcio https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d/
+The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. October, 2022, Sigstore was marked publicly available for announced general avail for rekor and fulcio https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d/
 
 ## Relevant Research
 

--- a/content/en/history.md
+++ b/content/en/history.md
@@ -5,7 +5,7 @@ category: 'About sigstore'
 position: 4
 ---
 
-The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. October, 2022, Sigstore was marked publicly available for announced general avail for rekor and fulcio https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d/
+The Sigstore Rekor project was initiated by Luke Hinds with Red Hat as the founding company in mid-2020. Later, Bob Callaway and Dan Lorenc joined as co-founders of the Sigstore project, which launched in March 2021 with the three major projects of Rekor, Fulcio, and Cosign. Sigstore became a Linux Foundation project on March 9, 2021, [citing founding members](https://www.linuxfoundation.org/press-release/linux-foundation-announces-free-sigstore-signing-service-to-confirm-origin-and-authenticity-of-software/) that include Red Hat, Google, and Purdue University. October, 2022, Sigstore was marked publicly available for announced general availability for rekor and fulcio https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d/
 
 ## Relevant Research
 


### PR DESCRIPTION
This PR fixes build instructions and includes some fixes requested by engineering.

This PR is for issue "Fix Sigstore/docs build instructions #88"



#### Summary

When trying to build the sigstore/docs website, an error occurs and the build fails.  This PR includes a workaround that corrects this error.   

This PR also edits some doc files as requested by engineering.

#### Release Note
NONE


#### Documentation
Changes to documentation:

README.md updated with instruction on how to avoid error.
history.md updated with more precise historical context.
working-with-blobs.md sget section removed as requested.
installation.md download cosign binary instruction added.
kubernetes.md edit message removed.
