### PR TITLE
Update overview.md

### DIFF
--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -36,7 +36,7 @@ $ cosign sign-blob <file> --bundle cosign.bundle
 
 The bundle contains signing metadata, including the signature and certificate.  
 
-The Cosign command requests a certificate from our certificate authority, Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to look at your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using our transparency log, Rekor.
+The Cosign command requests a certificate from our certificate authority, Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to look at your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using our transparency and timestamping log, Rekor.
  
 Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft, which will associate your identity with a short-lived signing key. For more information, read [Keyless Signatures](https://docs.sigstore.dev/cosign/keyless/).
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -80,7 +80,7 @@ $ cosign verify <image URI> --certificate-identity=name@example.com
 ```
 ### Signing with a generated key
 
-Although you do not have to use an existing key, you can generate a key or use an existing key for signing.  However, it is recommended that you use keyless signing, as a main feature of Sigstore is to make signatures invisible infrastructure.
+It it recommended that you use keyless signing, as a main feature of Sigstore is to make signatures invisible infrastructure that do not require key management. However, Sigstore allows you to use an existing key or generate a key if you prefer.
 
 To generate keys using Cosign, use the `cosign generate-key-pair` command.
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -102,6 +102,6 @@ To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review Signin
 Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official GitHub Actions Cosign installer or use cosign to generate and work safely with SCM secrets with native API integration.
 
 ### Attestations
-In addition to signatures, Cosign can be used with In-Toto Attestations.
+In addition to signatures, Cosign can be used with [In-Toto Attestations](https://github.com/in-toto/attestation).
 
 Attestations provide an additional semantic-layer on top of plain cryptographic signatures that can be used in policy systems.

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -70,7 +70,7 @@ Signing and verifying a container is similar to working with blobs.  The Cosign 
 $ cosign sign <image URI>
 ```
 
-This works the same as signing a blob, but the signature becomes attached to the container itself.
+This works the same as signing a blob, but the signature and certificate are attached as container metadata.
 
 To verify a signed container image, use the following command:
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -17,7 +17,7 @@ features:
 
 ## Getting Started (Quick Start)
 
-Cosign is part of the Sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/) (need an [invite](https://links.sigstore.dev/slack-invite)?)
+Cosign is part of the Sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/). (Need an [invite](https://links.sigstore.dev/slack-invite)?)
 
 ### Installation
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -49,11 +49,13 @@ cosign sign-blob --help
 ### Verifying a signed blob
 
 To verify a signed blob, you need to provide three pieces of information:
-* The certificate, found in the bundle
-* The signature, also found in the bundle
+* The certificate
+* The signature
 * The identity used in signing
 
-The following example verifies the signature on file.txt from user "name@example.com" issued by "accounts@example.com":
+You may be provided with a bundle that includes the certificate and signature.  The blob maintainer should provide the trusted identity.
+
+The following example verifies the signature on file.txt from user "name@example.com" issued by "accounts@example.com".  It uses a provided bundle "cosign.bundle" that contains the certificate and signature.
 
 ```
 $ cosign verify-blob <file> --bundle cosign.bundle --certificate-identity=name@example.com 
@@ -81,10 +83,10 @@ $ cosign verify <image URI>
 
 While you do not have to use an existing key you can generate a key and sign with it or another key you may wish to use.  However, it is recommended that you use keyless signing.
 
-To generate keys using a KMS provider, you can use the cosign generate-key-pair command with the --kms flag.
+To generate keys using Cosign, use the cosign generate-key-pair command.
 
 ```
-$ cosign generate-key-pair --kms <some provider>://<some key>
+$ cosign generate-key-pair 
 ```
 
 The following example shows the process of signing with an existing key. You must enter the password of the private key to sign.

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -100,7 +100,7 @@ Cosign is useful not only for blobs, containers, and container-related artifacts
 To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review [Signing Other Types](/cosign/other_types/). For more information about blobs, review [Working with Blobs](/cosign/working_with_blobs/).
 
 ### SCM Integration
-Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official [GitHub Actions Cosign installer](https://github.com/marketplace/actions/cosign-installer) or use cosign to generate and work safely with [SCM secrets](https://docs.sigstore.dev/cosign/git_support/) with native API integration.
+Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official [GitHub Actions Cosign installer](https://github.com/marketplace/actions/cosign-installer) or use cosign to generate and work safely with [SCM secrets](/cosign/git_support/) with native API integration.
 
 ### Attestations
 In addition to signatures, Cosign can be used with [In-Toto Attestations](https://github.com/in-toto/attestation).

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -99,7 +99,7 @@ Cosign is useful not only for blobs, containers, and container-related artifacts
 To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review Signing Other Types. For basic blobs, review Working with Blobs.
 
 ### SCM Integration
-Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official [GitHub Actions Cosign installer](https://github.com/marketplace/actions/cosign-installer) or use cosign to generate and work safely with SCM secrets with native API integration.
+Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official [GitHub Actions Cosign installer](https://github.com/marketplace/actions/cosign-installer) or use cosign to generate and work safely with [SCM secrets](https://docs.sigstore.dev/cosign/git_support/) with native API integration.
 
 ### Attestations
 In addition to signatures, Cosign can be used with [In-Toto Attestations](https://github.com/in-toto/attestation).

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -56,7 +56,7 @@ To verify a signed blob, you need to provide three pieces of information:
 The following example verifies the signature on file.txt from user "name@example.com" issued by "accounts@example.com":
 
 ```
-$ cosign verify-blob file.txt --bundle txtbundle.bundle --certificate-identity=name@example.com 
+$ cosign verify-blob <file> --bundle cosign.bundle --certificate-identity=name@example.com 
                               --certificate-oidc-issuer=https://accounts.example.com
 ```
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -60,7 +60,7 @@ $ cosign verify-blob <file> --bundle cosign.bundle --certificate-identity=name@e
                               --certificate-oidc-issuer=https://accounts.example.com
 ```
 
-To verify, Cosign queries the transparency log to compare the public key to what’s in Rekor, and checks the timestamp on the signature against the artifact’s entry in the transparency log. The signature is valid if its timestamp falls within the small window of time that the key pair and certificate issued by OpenID Connect were valid.
+To verify, Cosign queries the transparency log (Rekor) to compare the public key,, and checks the timestamp on the signature against the artifact’s entry in the transparency log. The signature is valid if its timestamp falls within the small window of time that the key pair and certificate issued by the certificate authority were valid.
 
 ### Working with containers
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -82,7 +82,7 @@ $ cosign verify <image URI>
 ```
 ### Signing with a generated key
 
-While you do not have to use an existing key you can generate a key and sign with it or another key you may wish to use.  However, it is recommended that you use keyless signing as a main feature of Sigstore is to make signatures invisible infrastructure.
+Although you do not have to use an existing key, you can generate a key or use an existing key for signing.  However, it is recommended that you use keyless signing, as a main feature of Sigstore is to make signatures invisible infrastructure.
 
 To generate keys using Cosign, use the cosign generate-key-pair command.
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -96,7 +96,7 @@ Pushing signature to: index.docker.io/user/demo:sha256-87ef60f558bad79be4def8.si
 ### Other Formats
 Cosign is useful not only for blobs, containers, and container-related artifacts; it can also be used for other file types.
 
-To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review Signing Other Types. For basic blobs, review Working with Blobs.
+To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review [Signing Other Types](https://docs.sigstore.dev/cosign/other_types/). For more information about blobs, review [Working with Blobs](https://docs.sigstore.dev/cosign/working_with_blobs/).
 
 ### SCM Integration
 Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official [GitHub Actions Cosign installer](https://github.com/marketplace/actions/cosign-installer) or use cosign to generate and work safely with [SCM secrets](https://docs.sigstore.dev/cosign/git_support/) with native API integration.

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -34,7 +34,7 @@ $ cosign sign-blob <file> --bundle cosign.bundle
 
 The bundle contains signing metadata, including the signature and certificate.  
 
-The Cosign command requests a certificate from our certificate authority, Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to look at your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using our transparency and timestamping log, Rekor.
+The Cosign command requests a certificate from the Sigstore certificate authority, Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to confirm your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using the Sigstore transparency and timestamping log, Rekor.
  
 Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft, which will associate your identity with a short-lived signing key. For more information, read [Keyless Signatures](https://docs.sigstore.dev/cosign/keyless/).
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -21,7 +21,7 @@ Cosign is part of the Sigstore project. Join us on our [Slack channel](https://s
 
 ### Installation
 
-To use Sigstore, you need to install Cosign. Instructions to install Cosign can be found on the [Cosign Installation page](https://docs.sigstore.dev/cosign/installation/). 
+To sign software artifacts and verify signatures using Sigstore, you need to install Cosign. Instructions to install Cosign can be found on the [Cosign Installation page](/cosign/installation/). 
 
 This will allow you to sign both blobs and containers.   If you need a sample container to test signing with, you can create one by following [these instructions](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images).
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -38,7 +38,7 @@ The bundle contains signing metadata, including the signature and certificate.
 
 The Cosign command requests a certificate from our Certificate Authority, which is called Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to look at your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using our Transparency Log, which is called Rekor.
  
-Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft. For more information, read [Keyless Signatures](https://docs.sigstore.dev/cosign/keyless/).
+Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft, which will associate your identity with a short-lived signing key. For more information, read [Keyless Signatures](https://docs.sigstore.dev/cosign/keyless/).
 
 Cosign has additional options and features.   For more information enter the command:
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -81,7 +81,7 @@ $ cosign verify <image URI>
 ```
 ### Signing with a generated key
 
-While you do not have to use an existing key you can generate a key and sign with it or another key you may wish to use.  However, it is recommended that you use keyless signing.
+While you do not have to use an existing key you can generate a key and sign with it or another key you may wish to use.  However, it is recommended that you use keyless signing as a main feature of Sigstore is to make signatures invisible infrastructure.
 
 To generate keys using Cosign, use the cosign generate-key-pair command.
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -60,7 +60,7 @@ $ cosign verify-blob <file> --bundle cosign.bundle --certificate-identity=name@e
                               --certificate-oidc-issuer=https://accounts.example.com
 ```
 
-To verify, Cosign queries the transparency log (Rekor) to compare the public key,, and checks the timestamp on the signature against the artifact’s entry in the transparency log. The signature is valid if its timestamp falls within the small window of time that the key pair and certificate issued by the certificate authority were valid.
+To verify, Cosign queries the transparency log (Rekor) to compare the public key bound to the cerfiicate, and checks the timestamp on the signature against the artifact’s entry in the transparency log. The signature is valid if its timestamp falls within the small window of time that the key pair and certificate issued by the certificate authority were valid.
 
 ### Working with containers
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -36,7 +36,7 @@ $ cosign sign-blob <file> --bundle txtbundle.bundle
 
 The bundle contains signing metadata, including the signature and certificate.  
 
-The Cosign command requests a certificate from our Certificate Authority Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to look at your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using Rekor.
+The Cosign command requests a certificate from our Certificate Authority, which is called Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to look at your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using our Transparency Log, which is called Rekor.
  
 Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft. For more information, read [Keyless Signatures](https://docs.sigstore.dev/cosign/keyless/).
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -64,7 +64,7 @@ To verify, Cosign queries the transparency log to compare the public key to what
 
 ### Working with containers
 
-Signing and verifying a container is similar to working with blobs.   The Cosign command to sign a container image is:
+Signing and verifying a container is similar to working with blobs.  The Cosign command to sign a container image is:
 
 ```
 $ cosign sign <image URI>

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Cosign"
-menuTitle:"Overview"
+menuTitle: "Overview"
 description: ""
 category: "Cosign"
 position: 100

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -60,7 +60,7 @@ $ cosign verify-blob <file> --bundle cosign.bundle --certificate-identity=name@e
                               --certificate-oidc-issuer=https://accounts.example.com
 ```
 
-To verify, Cosign queries the transparency log (Rekor) to compare the public key bound to the cerfiicate, and checks the timestamp on the signature against the artifact’s entry in the transparency log. The signature is valid if its timestamp falls within the small window of time that the key pair and certificate issued by the certificate authority were valid.
+To verify, Cosign queries the transparency log (Rekor) to compare the public key bound to the certificate, and checks the timestamp on the signature against the artifact’s entry in the transparency log. The signature is valid if its timestamp falls within the small window of time that the key pair and certificate issued by the certificate authority were valid.
 
 ### Working with containers
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -97,7 +97,7 @@ Pushing signature to: index.docker.io/user/demo:sha256-87ef60f558bad79be4def8.si
 ### Other Formats
 Cosign is useful not only for blobs, containers, and container-related artifacts; it can also be used for other file types.
 
-To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review [Signing Other Types](https://docs.sigstore.dev/cosign/other_types/). For more information about blobs, review [Working with Blobs](https://docs.sigstore.dev/cosign/working_with_blobs/).
+To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review [Signing Other Types](/cosign/other_types/). For more information about blobs, review [Working with Blobs](/cosign/working_with_blobs/).
 
 ### SCM Integration
 Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official [GitHub Actions Cosign installer](https://github.com/marketplace/actions/cosign-installer) or use cosign to generate and work safely with [SCM secrets](https://docs.sigstore.dev/cosign/git_support/) with native API integration.

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -87,7 +87,7 @@ To generate keys using a KMS provider, you can use the cosign generate-key-pair 
 $ cosign generate-key-pair --kms <some provider>://<some key>
 ```
 
-The following example shows the process of signing with an existing key.  You must enter the password of the private key to sign.
+The following example shows the process of signing with an existing key. You must enter the password of the private key to sign.
 ```
 $ cosign sign --key cosign.key user/demo
 Enter password for private key:

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -93,3 +93,15 @@ $ cosign sign --key cosign.key user/demo
 Enter password for private key:
 Pushing signature to: index.docker.io/user/demo:sha256-87ef60f558bad79be4def8.sig
 ```
+### Other Formats
+Cosign is useful not only for blobs, containers, and container-related artifacts; it can also be used for other file types.
+
+To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review Signing Other Types. For basic blobs, review Working with Blobs.
+
+### SCM Integration
+Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official GitHub Actions Cosign installer or use cosign to generate and work safely with SCM secrets with native API integration.
+
+### Attestations
+In addition to signatures, Cosign can be used with In-Toto Attestations.
+
+Attestations provide an additional semantic-layer on top of plain cryptographic signatures that can be used in policy systems.

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Cosign"
-menuTitle: "Quick Start"
+menuTitle:"Overview"
 description: ""
 category: "Cosign"
 position: 100

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -21,9 +21,7 @@ Cosign is part of the Sigstore project. Join us on our [Slack channel](https://s
 
 ### Installation
 
-To sign software artifacts and verify signatures using Sigstore, you need to install Cosign. Instructions to install Cosign can be found on the [Cosign Installation page](/cosign/installation/). 
-
-This will allow you to sign both blobs and containers.   If you need a sample container to test signing with, you can create one by following [these instructions](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images).
+To sign software artifacts and verify signatures using Sigstore, you need to install Cosign. Instructions to install Cosign can be found on the [Cosign Installation page](/cosign/installation/). This will allow you to sign and verify both blobs and containers.  
 
 ### Signing a blob
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -82,7 +82,7 @@ $ cosign verify <image URI> --certificate-identity=name@example.com
 
 Although you do not have to use an existing key, you can generate a key or use an existing key for signing.  However, it is recommended that you use keyless signing, as a main feature of Sigstore is to make signatures invisible infrastructure.
 
-To generate keys using Cosign, use the cosign generate-key-pair command.
+To generate keys using Cosign, use the `cosign generate-key-pair` command.
 
 ```
 $ cosign generate-key-pair 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -78,7 +78,8 @@ This works the same as signing a blob, but the signature and certificate are att
 To verify a signed container image, use the following command:
 
 ```
-$ cosign verify <image URI>
+$ cosign verify <image URI> --certificate-identity=name@example.com 
+                            --certificate-oidc-issuer=https://accounts.example.com
 ```
 ### Signing with a generated key
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -69,7 +69,8 @@ To verify, Cosign queries the transparency log to compare the public key to what
 Signing and verifying a container is similar to working with blobs.  The Cosign command to sign a container image is:
 
 ```
-$ cosign sign <image URI>
+$ cosign sign <image URI> --certificate-identity=name@example.com 
+                          --certificate-oidc-issuer=https://accounts.example.com
 ```
 
 This works the same as signing a blob, but the signature and certificate are attached as container metadata.

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -21,7 +21,7 @@ Cosign is part of the Sigstore project. Join us on our [Slack channel](https://s
 
 ### Installation
 
-To get sigstore up and running, you simply need to install Cosign. instructions to install Cosign can be found at https://docs.sigstore.dev/cosign/installation/. 
+To use Sigstore, you need to install Cosign. Instructions to install Cosign can be found on the [Cosign Installation page](https://docs.sigstore.dev/cosign/installation/). 
 
 This will allow you to sign both blobs and containers.   If you need a sample container to test signing with, you can create one by following the instructions at: https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Cosign"
-menuTitle: "Overview"
+menuTitle: "Quick Start"
 description: ""
 category: "Cosign"
 position: 100

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -23,7 +23,7 @@ Cosign is part of the Sigstore project. Join us on our [Slack channel](https://s
 
 To use Sigstore, you need to install Cosign. Instructions to install Cosign can be found on the [Cosign Installation page](https://docs.sigstore.dev/cosign/installation/). 
 
-This will allow you to sign both blobs and containers.   If you need a sample container to test signing with, you can create one by following the instructions at: https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images
+This will allow you to sign both blobs and containers.   If you need a sample container to test signing with, you can create one by following [these instructions](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images).
 
 ### Signing a blob
 
@@ -36,7 +36,7 @@ $ cosign sign-blob <file> --bundle cosign.bundle
 
 The bundle contains signing metadata, including the signature and certificate.  
 
-The Cosign command requests a certificate from our Certificate Authority, which is called Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to look at your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using our Transparency Log, which is called Rekor.
+The Cosign command requests a certificate from our certificate authority, Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to look at your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using our transparency log, Rekor.
  
 Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft, which will associate your identity with a short-lived signing key. For more information, read [Keyless Signatures](https://docs.sigstore.dev/cosign/keyless/).
 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -99,7 +99,7 @@ Cosign is useful not only for blobs, containers, and container-related artifacts
 To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review Signing Other Types. For basic blobs, review Working with Blobs.
 
 ### SCM Integration
-Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official GitHub Actions Cosign installer or use cosign to generate and work safely with SCM secrets with native API integration.
+Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official [GitHub Actions Cosign installer](https://github.com/marketplace/actions/cosign-installer) or use cosign to generate and work safely with SCM secrets with native API integration.
 
 ### Attestations
 In addition to signatures, Cosign can be used with [In-Toto Attestations](https://github.com/in-toto/attestation).

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -17,9 +17,6 @@ features:
 
 ## Getting Started (Quick Start)
 
-Cosign supports blob and container signing, verification, and storage in an OCI registry.
-Cosign aims to make signatures invisible infrastructure.
-
 Cosign is part of the Sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/) (need an [invite](https://links.sigstore.dev/slack-invite)?)
 
 ### Installation

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -53,7 +53,7 @@ To verify a signed blob, you need to provide three pieces of information:
 
 You may be provided with a bundle that includes the certificate and signature.  The blob maintainer should provide the trusted identity.
 
-The following example verifies the signature on file.txt from user "name@example.com" issued by "accounts@example.com".  It uses a provided bundle "cosign.bundle" that contains the certificate and signature.
+The following example verifies the signature on `file.txt` from user `name@example.com` issued by `accounts@example.com`.  It uses a provided bundle `cosign.bundle` that contains the certificate and signature.
 
 ```
 $ cosign verify-blob <file> --bundle cosign.bundle --certificate-identity=name@example.com 

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -69,8 +69,7 @@ To verify, Cosign queries the transparency log to compare the public key to what
 Signing and verifying a container is similar to working with blobs.  The Cosign command to sign a container image is:
 
 ```
-$ cosign sign <image URI> --certificate-identity=name@example.com 
-                          --certificate-oidc-issuer=https://accounts.example.com
+$ cosign sign <image URI>
 ```
 
 This works the same as signing a blob, but the signature and certificate are attached as container metadata.

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -31,7 +31,7 @@ The basic signing format for a blob is as follows:
 
 
 ```
-$ cosign sign-blob <file> --bundle txtbundle.bundle
+$ cosign sign-blob <file> --bundle cosign.bundle
 ```
 
 The bundle contains signing metadata, including the signature and certificate.  

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -40,7 +40,7 @@ The Cosign command requests a certificate from our Certificate Authority, which 
  
 Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft, which will associate your identity with a short-lived signing key. For more information, read [Keyless Signatures](https://docs.sigstore.dev/cosign/keyless/).
 
-Cosign has additional options and features.   For more information enter the command:
+For more information about Cosign's additional options and features, run the command:
 
 ```
 cosign sign-blob --help

--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -36,7 +36,7 @@ The bundle contains signing metadata, including the signature and certificate.
 
 The Cosign command requests a certificate from the Sigstore certificate authority, Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to confirm your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using the Sigstore transparency and timestamping log, Rekor.
  
-Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft, which will associate your identity with a short-lived signing key. For more information, read [Keyless Signatures](https://docs.sigstore.dev/cosign/keyless/).
+Note that you don’t need to use a key to sign.  Currently, you can authenticate with Google, GitHub, or Microsoft, which will associate your identity with a short-lived signing key. For more information, read [Keyless Signatures](/cosign/keyless/).
 
 For more information about Cosign's additional options and features, run the command:
 

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -14,7 +14,7 @@ It’s free to use for all developers and software providers, with Sigstore’s 
 
 ## How to use Sigstore
 
-* Sign software artifacts with [Cosign](/cosign/overview/) — [Quick start](/cosign/overview)
+* Sign software artifacts with [Cosign](/cosign/overview/) — [Quick start](/cosign/overview/#quick-start)
 * Sign Git commits with [Gitsign](/gitsign/overview/) - [Quick start](/gitsign/overview/#quick-start)
 * Verify entries with [Rekor](/rekor/CLI/#verify-proof-of-entry)
 * Use the [policy controller](/policy-controller/overview/) to enfore Kubernetes policies

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -14,7 +14,7 @@ It’s free to use for all developers and software providers, with Sigstore’s 
 
 ## How to use Sigstore
 
-* Sign software artifacts with [Cosign](/cosign/overview/) — [Quick start](/cosign/overview/#Quick-Start)
+* Sign software artifacts with [Cosign](/cosign/overview/) — [Quick start](/cosign/overview)
 * Sign Git commits with [Gitsign](/gitsign/overview/) - [Quick start](/gitsign/overview/#quick-start)
 * Verify entries with [Rekor](/rekor/CLI/#verify-proof-of-entry)
 * Use the [policy controller](/policy-controller/overview/) to enfore Kubernetes policies

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -14,7 +14,7 @@ It’s free to use for all developers and software providers, with Sigstore’s 
 
 ## How to use Sigstore
 
-* Sign software artifacts with [Cosign](/cosign/overview/) — [Quick start](/cosign/overview/#getting-started-quick-start)
+* Sign software artifacts with [Cosign](/cosign/overview/) — [Quick start](/cosign/overview/#Quick-Start)
 * Sign Git commits with [Gitsign](/gitsign/overview/) - [Quick start](/gitsign/overview/#quick-start)
 * Verify entries with [Rekor](/rekor/CLI/#verify-proof-of-entry)
 * Use the [policy controller](/policy-controller/overview/) to enfore Kubernetes policies


### PR DESCRIPTION
This change closes "rewrite cosign quick start guide #93".

#### Summary
The current quick start guide is outdated and does not address the needs of most users.  This change attempts to correct these problems.

#### Release Note
NONE

#### Documentation

This changes should alter page https://docs.sigstore.dev/cosign/overview/#getting-started-quick-start