### PR TITLE
instructions for verifying cosign release

### DIFF
--- a/content/en/cosign/installation.md
+++ b/content/en/cosign/installation.md
@@ -4,7 +4,7 @@ category: "Cosign"
 position: 102
 ---
 
-## With Go 1.19+ 
+## With Go 1.19+
 
 If you have Go 1.19+, you can directly install Cosign by downloading the Cosign binary and running:
 
@@ -81,7 +81,7 @@ Cosign can be installed in your GitHub Actions using the [Cosign installer](http
 ```yaml
 uses: sigstore/cosign-installer@main
 with:
-  cosign-release: 'v2.0.0' # optional
+  cosign-release: "v2.0.0" # optional
 ```
 
 ## Container Images
@@ -108,6 +108,23 @@ $ crane ls gcr.io/projectsigstore/cosign/ci/cosign
 ```
 
 Further details and installation instructions for `crane` available via https://github.com/google/go-containerregistry/tree/main/cmd/crane
+
+## Verifying Cosign Releases
+
+Before using a downloaded Cosign binary, it's important to verify its authenticity to ensure that it hasn't been tampered with. The Cosign binary is signed both with keyless signing and an artifact key. You first need to verify Cosign with the artifact key, since you will need Cosign to verify the keyless signature.
+
+```console
+tuf-client get https://sigstore-tuf-root.storage.googleapis.com cosign.pub > cosign.pub
+
+curl -o cosign-release.sig -L https://github.com/sigstore/cosign/releases/download/<version>/cosign-<os>.sig
+base64 -d cosign-release.sig > cosign-release.sig.decoded
+
+curl -o cosign -L https://github.com/sigstore/cosign/releases/download/<version>/cosign-<os>
+
+openssl dgst -sha256 -verify cosign.pub -signature cosign-release.sig.decoded cosign
+```
+
+The `<version>`and `<os>` placeholders in the URLs should be replaced with the specific version and operating system that you want to download.
 
 ## Releases
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

This PR references and closes the issue: add instructions for verifying cosign releases #95 
#### Summary
The current installation guide for cosign doesn't include verifying the downloaded cosign release. This pull request solves the problem of potential security vulnerabilities that could arise from using an unverified binary. 

#### Release Note
NONE

#### Documentation

The instructions are included in the "Verifying Cosign Releases" section on the Installation page of cosign documentation.
Here is a link to the page that might reflect the changes: https://docs.sigstore.dev/cosign/installation/
