### PR TITLE
Installation changes

### DIFF
--- a/content/en/cosign/installation.md
+++ b/content/en/cosign/installation.md
@@ -109,6 +109,31 @@ $ crane ls gcr.io/projectsigstore/cosign/ci/cosign
 
 Further details and installation instructions for `crane` available via https://github.com/google/go-containerregistry/tree/main/cmd/crane
 
+## Downloading The Update Framework (TUF) client
+
+Before using cosign, you will need to download and also initialize the TUF environment which allows you to ensure that your software artifacts are distributed securely and that any updates to these artifacts are signed and verified being installed.
+
+To do this, install and use [go-tuf](https://github.com/theupdateframework/go-tuf)'s CLI tools:
+
+```console
+$ go install github.com/theupdateframework/go-tuf/cmd/tuf-client@latest
+```
+
+Then, obtain trusted root keys for Sigstore. You will use the 5th iteration of Sigstore's TUF root to start the root of trust, due to
+a backwards incompatible change.
+
+```console
+curl -o sigstore-root.json https://raw.githubusercontent.com/sigstore/root-signing/main/ceremony/2022-10-18/repository/5.root.json
+```
+
+## Initializing TUF Environment
+
+Then initialize the tuf client with the previously obtained root key and the remote repository;
+
+```console
+$ tuf-client init https://sigstore-tuf-root.storage.googleapis.com sigstore-root.json
+```
+
 ## Verifying Cosign Releases
 
 Before using a downloaded Cosign binary, it's important to verify its authenticity to ensure that it hasn't been tampered with. The Cosign binary is signed both with keyless signing and an artifact key. You first need to verify Cosign with the artifact key, since you will need Cosign to verify the keyless signature.

--- a/content/en/cosign/installation.md
+++ b/content/en/cosign/installation.md
@@ -4,7 +4,7 @@ category: "Cosign"
 position: 102
 ---
 
-## With Go 1.19+ 
+## With Go 1.19+
 
 If you have Go 1.19+, you can directly install Cosign by downloading the Cosign binary and running:
 
@@ -81,7 +81,7 @@ Cosign can be installed in your GitHub Actions using the [Cosign installer](http
 ```yaml
 uses: sigstore/cosign-installer@main
 with:
-  cosign-release: 'v2.0.0' # optional
+  cosign-release: "v2.0.0" # optional
 ```
 
 ## Container Images
@@ -108,6 +108,23 @@ $ crane ls gcr.io/projectsigstore/cosign/ci/cosign
 ```
 
 Further details and installation instructions for `crane` available via https://github.com/google/go-containerregistry/tree/main/cmd/crane
+
+## Verifying Cosign Releases
+
+Before using a downloaded Cosign binary, it's important to verify its authenticity to ensure that it hasn't been tampered with. The Cosign binary is signed both with keyless signing and an artifact key. You first need to verify Cosign with the artifact key, since you will need Cosign to verify the keyless signature.
+
+```console
+tuf-client get https://sigstore-tuf-root.storage.googleapis.com cosign.pub > cosign.pub
+
+curl -o cosign-release.sig -L https://github.com/sigstore/cosign/releases/download/<version>/cosign-<os>.sig
+base64 -d cosign-release.sig > cosign-release.sig.decoded
+
+curl -o cosign -L https://github.com/sigstore/cosign/releases/download/<version>/cosign-<os>
+
+openssl dgst -sha256 -verify cosign.pub -signature cosign-release.sig.decoded cosign
+```
+
+The `<version>`and `<os>` placeholders in the URLs should be replaced with the specific version and operating system that you want to download.
 
 ## Releases
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
This pull request references and closes issue #99.
#### Summary

 The current installation guide for cosign doesn't include verifying the downloaded cosign release. This pull request solves the problem of potential security vulnerabilities that arise from using an unprotected binary, by also using the fulcio readme as a guide, instructions on how to download and initialize the tuf environment had been added.

#### Release Note
NONE

#### Documentation
The instructions are included in the 'Verifying cosign releases" section on the installation page of cosign documentation.

<img width="1280" alt="Screenshot 2023-03-29 at 15 41 53" src="https://user-images.githubusercontent.com/66581497/228581130-9db75047-e39f-423d-826e-c76e05e37c12.png">

<img width="1280" alt="Screenshot 2023-03-29 at 15 41 59" src="https://user-images.githubusercontent.com/66581497/228581598-d65c0a16-496c-467e-bec8-9c6a22ca71db.png">

Attached above are the changes made as reflected on the localhost.
