### PR TITLE
added explanation of cosign

### DIFF
--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -17,25 +17,26 @@ features:
 
 ## Getting Started (Quick Start)
 
-Cosign is part of the Sigstore project. Join us on our [Slack channel](https://sigstore.slack.com/). (Need an [invite](https://links.sigstore.dev/slack-invite)?)
+Cosign is a tool developed as part of the Sigstore project used to verify and sign container images, ensuring their integrity and authenticity.It can also work with blobs, which are binary large objects or files that you can use to store and transfer data.
+
+Join us on our [Slack channel](https://sigstore.slack.com/). (Need an [invite](https://links.sigstore.dev/slack-invite)?)
 
 ### Installation
 
-To sign software artifacts and verify signatures using Sigstore, you need to install Cosign. Instructions to install Cosign can be found on the [Cosign Installation page](/cosign/installation/). This will allow you to sign and verify both blobs and containers.  
+To sign software artifacts and verify signatures using Sigstore, you need to install Cosign. Instructions to install Cosign can be found on the [Cosign Installation page](/cosign/installation/). This will allow you to sign and verify both blobs and containers.
 
 ### Signing a blob
 
 The basic signing format for a blob is as follows:
 
-
 ```
 $ cosign sign-blob <file> --bundle cosign.bundle
 ```
 
-The bundle contains signing metadata, including the signature and certificate.  
+The bundle contains signing metadata, including the signature and certificate.
 
-The Cosign command requests a certificate from the Sigstore certificate authority, Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to confirm your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity.  This activity is logged using the Sigstore transparency and timestamping log, Rekor.
- 
+The Cosign command requests a certificate from the Sigstore certificate authority, Fulcio. Fulcio checks your identity by using an authentication protocol (OpenID Connect) to confirm your email address. If your identity is correct, Fulcio grants a short-lived, time-stamped certificate. The certificate is bound to the public key to attest to your identity. This activity is logged using the Sigstore transparency and timestamping log, Rekor.
+
 Note that you don’t need to use a key to sign. Currently, you can authenticate with Google, GitHub, or Microsoft, which will associate your identity with a short-lived signing key. For more information, read [Keyless Signatures](/cosign/keyless/).
 
 For more information about Cosign's additional options and features, run the command:
@@ -47,16 +48,17 @@ cosign sign-blob --help
 ### Verifying a signed blob
 
 To verify a signed blob, you need to provide three pieces of information:
-* The certificate
-* The signature
-* The identity used in signing
 
-You may be provided with a bundle that includes the certificate and signature.  The blob maintainer should provide the trusted identity.
+- The certificate
+- The signature
+- The identity used in signing
 
-The following example verifies the signature on `file.txt` from user `name@example.com` issued by `accounts@example.com`.  It uses a provided bundle `cosign.bundle` that contains the certificate and signature.
+You may be provided with a bundle that includes the certificate and signature. The blob maintainer should provide the trusted identity.
+
+The following example verifies the signature on `file.txt` from user `name@example.com` issued by `accounts@example.com`. It uses a provided bundle `cosign.bundle` that contains the certificate and signature.
 
 ```
-$ cosign verify-blob <file> --bundle cosign.bundle --certificate-identity=name@example.com 
+$ cosign verify-blob <file> --bundle cosign.bundle --certificate-identity=name@example.com
                               --certificate-oidc-issuer=https://accounts.example.com
 ```
 
@@ -64,7 +66,7 @@ To verify, Cosign queries the transparency log (Rekor) to compare the public key
 
 ### Working with containers
 
-Signing and verifying a container is similar to working with blobs.  The Cosign command to sign a container image is:
+Signing and verifying a container is similar to working with blobs. The Cosign command to sign a container image is:
 
 ```
 $ cosign sign <image URI>
@@ -75,9 +77,10 @@ This works the same as signing a blob, but the signature and certificate are att
 To verify a signed container image, use the following command:
 
 ```
-$ cosign verify <image URI> --certificate-identity=name@example.com 
+$ cosign verify <image URI> --certificate-identity=name@example.com
                             --certificate-oidc-issuer=https://accounts.example.com
 ```
+
 ### Signing with a generated key
 
 It is recommended that you use keyless signing, as a main feature of Sigstore is to make signatures invisible infrastructure that do not require key management. However, Sigstore allows you to use an existing key or generate a key if you prefer.
@@ -85,24 +88,29 @@ It is recommended that you use keyless signing, as a main feature of Sigstore is
 To generate keys using Cosign, use the `cosign generate-key-pair` command.
 
 ```
-$ cosign generate-key-pair 
+$ cosign generate-key-pair
 ```
 
 The following example shows the process of signing with an existing key. You must enter the password of the private key to sign.
+
 ```
 $ cosign sign --key cosign.key user/demo
 Enter password for private key:
 Pushing signature to: index.docker.io/user/demo:sha256-87ef60f558bad79be4def8.sig
 ```
+
 ### Other Formats
+
 Cosign is useful not only for blobs, containers, and container-related artifacts; it can also be used for other file types.
 
 To learn how to sign SBOMs, WASM modules, Tekton bundles and more, review [Signing Other Types](/cosign/other_types/). For more information about blobs, review [Working with Blobs](/cosign/working_with_blobs/).
 
 ### SCM Integration
+
 Cosign integrates natively with source code management (SCM) systems like GitHub and GitLab. You can use the official [GitHub Actions Cosign installer](https://github.com/marketplace/actions/cosign-installer) or use cosign to generate and work safely with [SCM secrets](/cosign/git_support/) with native API integration.
 
 ### Attestations
+
 In addition to signatures, Cosign can be used with [In-Toto Attestations](https://github.com/in-toto/attestation).
 
 Attestations provide an additional semantic-layer on top of plain cryptographic signatures that can be used in policy systems.


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

This PR resolves and closes issue #112 
#### Summary
The overview page for cosign doesn't explain the purpose of cosign and its capabilities. This PR gives a brief explanation of cosign to give the users an understanding of cosign's purpose.

#### Release Note
NONE

#### Documentation
The changes are reflected in the overview page of cosign's section in the docs. Attached below are the changes as reflected on localhost.
<img width="702" alt="Screenshot 2023-04-07 at 15 42 49" src="https://user-images.githubusercontent.com/66581497/230629526-66dcfaf1-a481-44cf-9c1d-6b29c1dca5ce.png">

