### PR TITLE
chore(docs) updates hardware token docs

### DIFF
--- a/content/en/cosign/hardware-based-tokens.md
+++ b/content/en/cosign/hardware-based-tokens.md
@@ -6,23 +6,30 @@ position: 114
 
 The `cosign` command line tool optionally supports hardware tokens for signing and key management.
 This support is enabled through the [PIV protocol](https://csrc.nist.gov/projects/piv/piv-standards-and-supporting-documentation)
-and the [go-piv](https://github.com/go-piv/piv-go) library, which is not included in the standard release. Use [`make cosign-pivkey`](https://github.com/sigstore/cosign/blob/a8d1cc1132d4a019a62ff515b9375c8c5b98a5c5/Makefile#L52), or `go build -tags=pivkey`, to build `cosign` with support for hardware tokens.
+and the [go-piv](https://github.com/go-piv/piv-go) library, which is not included in the standard release. Use `make cosign-pivkey-pkcs11key`, or `go build -tags=pivkey,pkcs11key ./cmd/cosign`, to build `cosign` with support for hardware tokens.
 
 ---
 **NOTE**
 
-Cosign's hardware token support requires `libpcsclite` on platforms other than Windows and OSX.
+`cosign`'s hardware token support requires `libpcsclite` on platforms other than Windows and OSX.
 See [`go-piv`'s installation instructions for your platform.](https://github.com/go-piv/piv-go#installation)
 
 ---
 
 We recommend using an application provided by your hardware vendor to manage keys and permissions for advanced use-cases, but `cosign piv-tool` should work well for most users.
 
+The following exmamples use this image:
+
+```shell
+$ IMAGE=gcr.io/dlorenc-vmtest2/demo
+$ IMAGE_DIGEST=$IMAGE@sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd
+```
+
 ## Quick Start
 
 ### Setup
 
-To get started, insert a key to your computer and run the `cosign generate-key` command.
+To get started, insert a key to your computer and run the `cosign piv-tool generate-key` command.
 We recommend using the `--random-management-key=true` flag.
 
 This command generates a cryptographically-random management key and configures the device to use it.
@@ -95,24 +102,24 @@ You can then use the normal `cosign` commands to sign images and blobs with your
 **NOTE**: The default PIN is `123456`.
 
 ```shell
-$ cosign sign --sk gcr.io/user-vmtest2/demo
+$ cosign sign --sk $IMAGE_DIGEST
 Enter PIN for security key:
 Please tap security key...
-Pushing signature to: gcr.io/user-vmtest2/demo:sha256-410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd.sig
+Pushing signature to: gcr.io/dlorenc-vmtest2/demo:sha256-410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd.sig
 ```
 
 To verify, you can either use the hardware key directly:
 
 ```shell
-$ cosign verify --sk gcr.io/user-vmtest2/demo
+$ cosign verify --sk $IMAGE_DIGEST
 
-Verification for gcr.io/user-vmtest2/demo --
+Verification for gcr.io/dlorenc-vmtest2/demo --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - The signatures were verified against the specified public key
-  - Any certificates were verified against the Fulcio roots.
+  - The code-signing certificate was verified using trusted certificate authority certificates
 
-[{"critical":{"identity":{"docker-reference":"gcr.io/user-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd"},"type":"cosign container image signature"},"optional":null}]
+[{"critical":{"identity":{"docker-reference":"gcr.io/dlorenc-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd"},"type":"cosign container image signature"},"optional":null}]
 ```
 
 Or export the public key and verify against that:
@@ -120,15 +127,15 @@ Or export the public key and verify against that:
 ```shell
 $ cosign public-key --sk > pub.key
 
-$ cosign verify --key pub.key gcr.io/user-vmtest2/demo
+$ cosign verify --key pub.key $IMAGE
 
-Verification for gcr.io/user-vmtest2/demo --
+Verification for gcr.io/dlorenc-vmtest2/demo --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - The signatures were verified against the specified public key
-  - Any certificates were verified against the Fulcio roots.
+  - The code-signing certificate was verified using trusted certificate authority certificates
 
-[{"critical":{"identity":{"docker-reference":"gcr.io/user-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd"},"type":"cosign container image signature"},"optional":null}]
+[{"critical":{"identity":{"docker-reference":"gcr.io/dlorenc-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd"},"type":"cosign container image signature"},"optional":null}]
 ```
 
 ## CLI Usage

--- a/content/en/cosign/hardware-based-tokens.md
+++ b/content/en/cosign/hardware-based-tokens.md
@@ -11,7 +11,7 @@ and the [go-piv](https://github.com/go-piv/piv-go) library, which is not include
 ---
 **NOTE**
 
-`cosign`'s hardware token support requires `libpcsclite` on platforms other than Windows and OSX.
+Cosign's hardware token support requires `libpcsclite` on platforms other than Windows and OSX.
 See [`go-piv`'s installation instructions for your platform.](https://github.com/go-piv/piv-go#installation)
 
 ---

--- a/content/en/cosign/hardware-based-tokens.md
+++ b/content/en/cosign/hardware-based-tokens.md
@@ -21,7 +21,7 @@ We recommend using an application provided by your hardware vendor to manage key
 The following exmamples use this image:
 
 ```shell
-$ IMAGE=gcr.io/dlorenc-vmtest2/demo
+$ IMAGE=gcr.io/user-vmtest2/demo
 $ IMAGE_DIGEST=$IMAGE@sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd
 ```
 
@@ -105,7 +105,7 @@ You can then use the normal `cosign` commands to sign images and blobs with your
 $ cosign sign --sk $IMAGE_DIGEST
 Enter PIN for security key:
 Please tap security key...
-Pushing signature to: gcr.io/dlorenc-vmtest2/demo:sha256-410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd.sig
+Pushing signature to: gcr.io/user-vmtest2/demo:sha256-410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd.sig
 ```
 
 To verify, you can either use the hardware key directly:
@@ -113,13 +113,13 @@ To verify, you can either use the hardware key directly:
 ```shell
 $ cosign verify --sk $IMAGE_DIGEST
 
-Verification for gcr.io/dlorenc-vmtest2/demo --
+Verification for gcr.io/user-vmtest2/demo --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - The signatures were verified against the specified public key
   - The code-signing certificate was verified using trusted certificate authority certificates
 
-[{"critical":{"identity":{"docker-reference":"gcr.io/dlorenc-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd"},"type":"cosign container image signature"},"optional":null}]
+[{"critical":{"identity":{"docker-reference":"gcr.io/user-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd"},"type":"cosign container image signature"},"optional":null}]
 ```
 
 Or export the public key and verify against that:
@@ -129,13 +129,13 @@ $ cosign public-key --sk > pub.key
 
 $ cosign verify --key pub.key $IMAGE
 
-Verification for gcr.io/dlorenc-vmtest2/demo --
+Verification for gcr.io/user-vmtest2/demo --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - The signatures were verified against the specified public key
   - The code-signing certificate was verified using trusted certificate authority certificates
 
-[{"critical":{"identity":{"docker-reference":"gcr.io/dlorenc-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd"},"type":"cosign container image signature"},"optional":null}]
+[{"critical":{"identity":{"docker-reference":"gcr.io/user-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd"},"type":"cosign container image signature"},"optional":null}]
 ```
 
 ## CLI Usage


### PR DESCRIPTION
- updates and migrates Harware Tokens docs as part of documentation migration https://github.com/sigstore/cosign/issues/822

This aims to deprecate https://github.com/sigstore/cosign/blob/main/TOKENS.md

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>