### PR TITLE
Fix staging root mirror url in public deployment doc

### DIFF
--- a/content/en/cosign/public_deployment.md
+++ b/content/en/cosign/public_deployment.md
@@ -22,7 +22,7 @@ To use this instance, follow the steps below:
 
 1. `rm -r ~/.sigstore`
 1. `curl -O https://raw.githubusercontent.com/sigstore/root-signing/main/staging/repository/1.root.json`
-1. `cosign initialize --mirror=https://tuf-repo-cdn.sigstore.dev --root=1.root.json`
+1. `cosign initialize --mirror=https://tuf-repo-cdn.sigstage.dev --root=1.root.json`
 1. `cosign sign --oidc-issuer "https://oauth2.sigstage.dev/auth" --fulcio-url "https://fulcio.sigstage.dev" --rekor-url "https://rekor.sigstage.dev" ${IMAGE_DIGEST}`
 1. `cosign verify --rekor-url "https://rekor.sigstage.dev" ${IMAGE}` --certificate-identity=name@example.com
                                                                      --certificate-oidc-issuer=https://accounts.example.com


### PR DESCRIPTION
#### Summary

The instructions to initialize cosign with the staging root indicate to use the production TUF mirror, which fails because the keys are different:

```
$ cosign initialize --mirror=https://tuf-repo-cdn.sigstore.dev --root=1.root.json
```

<details>

<summary>initialize error</summary>

```
Error: updating local metadata and targets: error updating to TUF remote mirror: tuf: valid signatures did not meet threshold
remote status:{
	"mirror": "https://tuf-repo-cdn.sigstore.dev",
	"metadata": {
		"root.json": {
			"version": 7,
			"len": 5404,
			"expiration": "04 Oct 23 13:08 UTC",
			"error": ""
		},
		"snapshot.json": {
			"version": 90,
			"len": 2303,
			"expiration": "03 Jul 23 16:03 UTC",
			"error": ""
		},
		"targets.json": {
			"version": 7,
			"len": 5252,
			"expiration": "04 Oct 23 13:26 UTC",
			"error": ""
		},
		"timestamp.json": {
			"version": 90,
			"len": 721,
			"expiration": "26 Jun 23 16:03 UTC",
			"error": ""
		}
	}
}
main.go:74: error during command execution: updating local metadata and targets: error updating to TUF remote mirror: tuf: valid signatures did not meet threshold
remote status:{
	"mirror": "https://tuf-repo-cdn.sigstore.dev",
	"metadata": {
		"root.json": {
			"version": 7,
			"len": 5404,
			"expiration": "04 Oct 23 13:08 UTC",
			"error": ""
		},
		"snapshot.json": {
			"version": 90,
			"len": 2303,
			"expiration": "03 Jul 23 16:03 UTC",
			"error": ""
		},
		"targets.json": {
			"version": 7,
			"len": 5252,
			"expiration": "04 Oct 23 13:26 UTC",
			"error": ""
		},
		"timestamp.json": {
			"version": 90,
			"len": 721,
			"expiration": "26 Jun 23 16:03 UTC",
			"error": ""
		}
	}
}
```

</details>

Using the sigstage mirror, I was able to initialize successfully and sign an image against the staging infra. 

#### Release Note
NONE

#### Documentation

