### PR TITLE
add docs for sigstore/cosign pr3052

### DIFF
--- a/content/en/cosign/timestamps.md
+++ b/content/en/cosign/timestamps.md
@@ -50,8 +50,9 @@ cosign verify --timestamp-certificate-chain ts_chain.pem <artifact>
 ```
 
 ### mTLS connection to the TSA server
-`cosign sign` accept several additional optional parameters to pass the CA certificate of
-the TSA server in case it uses a custom CA or to establish mutual TLS connection to the TSA server:
+
+`cosign sign` accepts several additional optional parameters to pass the CA certificate of
+the TSA server in cases where it uses a custom CA, or to establish a mutual TLS connection to the TSA server:
 ```
     --timestamp-client-cacert='':
 	path to the X.509 CA certificate file in PEM format to be used for the connection to the

--- a/content/en/cosign/timestamps.md
+++ b/content/en/cosign/timestamps.md
@@ -49,6 +49,27 @@ To verify, retrieve the TSA's certificate chain, which must contain the root CA 
 cosign verify --timestamp-certificate-chain ts_chain.pem <artifact>
 ```
 
+### mTLS connection to the TSA server
+`cosign sign` accept several additional optional parameters to pass the CA certificate of
+the TSA server in case it uses a custom CA or to establish mutual TLS connection to the TSA server:
+```
+    --timestamp-client-cacert='':
+	path to the X.509 CA certificate file in PEM format to be used for the connection to the
+	TSA Server
+
+    --timestamp-client-cert='':
+	path to the X.509 certificate file in PEM format to be used for the connection to the TSA
+	Server
+
+    --timestamp-client-key='':
+	path to the X.509 private key file in PEM format to be used, together with the
+	'timestamp-client-cert' value, for the connection to the TSA Server
+
+    --timestamp-server-name='':
+	SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the
+	TSA Server
+```
+
 ## Future goals
 
 We would like to make timestamps immutable in Rekor. While the clock would not be verifiable and trust isn't distributed, it would make mutations to the timestamps detectable. We would like to include a signed timestamp, which could come from a 3rd party TSA or from a TSA operated by the Sigstore community, in the Rekor entry so that it is a part of the Merkle leaf hash computation and therefore becomes immutable. 


### PR DESCRIPTION
#### Summary
add documentation for the new command-line options to `cosign sign` related to the custom CA of the TSA server or to the mTLS connection to it.  Pull Request: https://github.com/sigstore/cosign/pull/3052, Issue: https://github.com/sigstore/cosign/issues/3006.

#### Release Note
- None


#### Documentation
- documentation new command-line parameters for `cosign sign` related to mTLS connection to the TSA Server / https://github.com/sigstore/cosign/pull/3052
