### PR TITLE
Updated package in Gitsign installation to v0.7.1

### DIFF
--- a/content/en/gitsign/installation.md
+++ b/content/en/gitsign/installation.md
@@ -40,8 +40,8 @@ Check the [releases page](https://github.com/sigstore/cosign/releases) for the
 latest release, and download the appropriate `.deb` file.
 
 ```console
-wget https://github.com/sigstore/gitsign/releases/download/v0.3.0/gitsign_0.3.0_linux_amd64.deb
-sudo dpkg -i gitsign_0.3.0_linux_amd64.deb
+wget https://github.com/sigstore/gitsign/releases/download/v0.7.1/gitsign_0.7.1_linux_amd64.deb
+sudo dpkg -i gitsign_0.7.1_linux_amd64.deb
 ```
 
 ### Installing Gitsign with the `.rpm` Package (Fedora Linux)
@@ -50,8 +50,8 @@ Check the [releases page](https://github.com/sigstore/cosign/releases) for the
 latest release, and download the appropriate `.rpm` file.
 
 ```console
-wget https://github.com/sigstore/gitsign/releases/download/v0.3.0/gitsign_0.3.0_linux_amd64.rpm
-rpm -ivh gitsign_0.3.0_linux_amd64.rpm
+wget https://github.com/sigstore/gitsign/releases/download/v0.7.1/gitsign_0.7.1_linux_amd64.rpm
+rpm -ivh gitsign_0.7.1_linux_amd64.rpm
 ```
 
 ## Checking your Installation
@@ -61,7 +61,7 @@ ensure that it can be found on your $PATH by running a `gitsign` command.
 
 ```shell
 $ gitsign --version
-gitsign version v0.3.0
+gitsign version v0.7.1
 ```
 
 ### Troubleshooting


### PR DESCRIPTION
#### Summary

This PR updates the package versions on the installation page for Gitsign. It addresses issue #137.


#### Release Note

This update changes the wget links for the debian-like and RPM releases and also updates the example version number when running `gitsign --version`.

Resolves #137