### PR TITLE
Update kms_support.md with ACL policies needed for Hashicorp Vault

### DIFF
--- a/content/en/cosign/kms_support.md
+++ b/content/en/cosign/kms_support.md
@@ -152,6 +152,26 @@ The URI format for Hashicorp Vault KMS is: `hashivault://$keyname`
 This provider requires that the standard Vault environment variables (`$VAULT_ADDR`, `$VAULT_TOKEN`) are set correctly.
 This provider also requires that the `transit` secret engine is enabled.
 
+The token needs (at least) the following permissions, that will be defined as an ACL policy in the next example. Suppose that the `transit` secret engine is mounted at the path `/transit`, and the `$keyname` is `cosign`, the policy would look like this:
+
+```hcl
+path "transit/keys/cosign" {
+  capabilities = ["read"]
+}
+
+path "transit/hmac/cosign/*" {
+  capabilities = ["update"]
+}
+
+path "transit/sign/cosign/*" {
+  capabilities = ["update"]
+}
+
+path "transit/verify/cosign" {
+  capabilities = ["create"]
+}
+```
+
 ### Kubernetes Secret
 
 Cosign can use keys stored in Kubernetes Secrets to so sign and verify signatures. In order to generate a secret you have to pass `cosign generate-key-pair` a `k8s://[NAMESPACE]/[NAME]` URI specifying the namespace and secret name:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Added documentation for the Hashicorp Vault provider regarding the minimum set of capabilities (ACL policies) that needs to be defined for cosign to work. I did not found this documented anywhere and had to trial and error for a while to get it working right, so I guess it could be of help to others too!
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
This is a change to the documentation, specifically related to https://github.com/sigstore/docs/blob/main/content/en/cosign/kms_support.md#hashicorp-vault