### PR TITLE
remove link to rekor-operator

### DIFF
--- a/content/en/rekor/installation.md
+++ b/content/en/rekor/installation.md
@@ -43,8 +43,7 @@ cp rekor-cli /usr/local/bin/
 There are a few ways you can deploy a Rekor Server:
 
 1.  We have a [docker-compose](https://github.com/sigstore/rekor/blob/main/docker-compose.yml) file available.
-2.  A [Kubernetes operator](https://github.com/sigstore/rekor-operator).
-3.  Alternatively, you can build a Rekor server yourself.
+2.  Alternatively, you can build a Rekor server yourself.
 
 Note: The Rekor server manually creates a new Merkle tree (or shard) in the Trillian backend every time it starts up, unless an existing one is specified in via the `--trillian_log_server.tlog_id` flag. If you are building the server yourself and do not need [sharding](/rekor/sharding/) functionality, you can find the existing tree's TreeID by issuing this client command while the server is running:
 


### PR DESCRIPTION
Since the operator is deprecated, we should remove the reference to it in the documentation.

close #37

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

The rekor-operator is deprecated, so it should be removed from documentation

#### Release Note

NONE

#### Documentation

N/A
