### PR TITLE
Fix link

### DIFF
--- a/content/en/cosign/overview.md
+++ b/content/en/cosign/overview.md
@@ -125,7 +125,7 @@ Cosign integrates natively with source code management (SCM) systems like GitHub
 
 In addition to signatures, Cosign can be used with [In-Toto Attestations](https://github.com/in-toto/attestation).
 
-Attestations provide an additional semantic-layer on top of plain cryptographic signatures that can be used in policy systems. Learn more in the [Attestations](/cosign/attestation) documentation.
+Attestations provide an additional semantic-layer on top of plain cryptographic signatures that can be used in policy systems. Learn more in the [Attestations](/cosign/attestation/) documentation.
 
 ## Other Formats
 


### PR DESCRIPTION
#### Summary

Clicking the link ends up on a page that says "This page could not be found", a redirect to the proper page is not happening.

[Preview of the affected part of the site](https://deploy-preview-208--docssigstore.netlify.app/cosign/overview/#attestations)

#### Release Note

NONE