### PR TITLE
ci(github action): add MarkdownLint linter support for main branch

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,33 @@
+name: MarkdownLint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: tj-actions/changed-files@v37
+        id: changed-files
+        with:
+          files: '**/*.md'
+          separator: ","
+
+      - uses: DavidAnson/markdownlint-cli2-action@v11
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          config: '.markdownlint-cli2.jsonc'
+          globs: ${{ steps.changed-files.outputs.all_changed_files }}
+          separator: ","
+        continue-on-error: true


### PR DESCRIPTION

#### Summary

Based on GitHub Action, add Markdown linter check support for the main branch.

When the main branch generates a new push or Pull Request, it will automatically check whether the changed Markdown file complies with the specification

#### Release Note

* Feat: add Markdown linter check support for main branch

#### Documentation

reslove #226 