### PR TITLE
add 'cosign sign-blob'in the mTLS TSA section

### DIFF
--- a/content/en/verifying/timestamps.md
+++ b/content/en/verifying/timestamps.md
@@ -52,7 +52,7 @@ cosign verify --timestamp-certificate-chain ts_chain.pem <artifact>
 
 ### mTLS connection to the TSA server
 
-`cosign sign` accepts several additional optional parameters to pass the CA certificate of
+`cosign sign` and `cosign sign-blob` accept several additional optional parameters to pass the CA certificate of
 the TSA server in cases where it uses a custom CA, or to establish a mutual TLS connection to the TSA server:
 ```
     --timestamp-client-cacert='':


### PR DESCRIPTION
#### Summary
PR extends https://github.com/sigstore/docs/pull/192 to add the `sign-blob` command as the one for which mTLS connection-to-TSA parameters are available. It accompanies the change in sigstore/cosign https://github.com/sigstore/cosign/pull/3200 and should be merged shortly after that one.  Related to https://github.com/sigstore/cosign/issues/3006.

#### Release Note
None

#### Documentation
- documentation new command-line parameters for `cosign sign` related to mTLS connection to the TSA Server / https://github.com/sigstore/cosign/pull/3052
