### PR TITLE
Updated redirects file for URLs under "about"

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,7 +1,7 @@
 #redirect file for moved web pages.
 /main-concepts                              /about/tooling
 /security                              /about/security
-/threat-model                              /about/threat-model/
+/threat-model                               /about/threat-model/
 /history                                    /about/research
 /cosign/overview                            /signing/quickstart
 /cosign/installation                        /system_config/installation

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,7 +1,9 @@
 #redirect file for moved web pages.
-/main-concepts                              /tooling
-/history                                    /research
-/cosign/overview                            /signing/quickstart    
+/main-concepts                              /about/tooling
+/security                              /about/security
+/threat-model                              /about/threat-model/
+/history                                    /about/research
+/cosign/overview                            /signing/quickstart
 /cosign/installation                        /system_config/installation
 /cosign/signing_with_self-managed_keys      /key_management/signing_with_self-managed_keys
 /cosign/import-keypair                      /key_management/import-keypair

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,6 @@
 #redirect file for moved web pages.
 /main-concepts                              /about/tooling
-/security                                  /about/security
+/security                                   /about/security
 /threat-model                               /about/threat-model/
 /history                                    /about/research
 /cosign/overview                            /signing/quickstart

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,6 +1,6 @@
 #redirect file for moved web pages.
 /main-concepts                              /about/tooling
-/security                              /about/security
+/security                                  /about/security
 /threat-model                               /about/threat-model/
 /history                                    /about/research
 /cosign/overview                            /signing/quickstart


### PR DESCRIPTION
## Summary

Some previous first-level URLs are now under "about". Added redirects for these so that inbound links will still work.

## Notes

Resolves #237