### PR TITLE
Change overview page title to "Overview"

### DIFF
--- a/content/en/about/overview.md
+++ b/content/en/about/overview.md
@@ -3,8 +3,7 @@ type: docs
 category: About Sigstore
 description: Documentation for Sigstore
 home: true
-menuTitle: Overview
-title: Sigstore
+title: Overview
 weight: 1
 ---
 


### PR DESCRIPTION
Changed overview page title to prevent redundant home page title ("Sigstore - Sigstore" to "Overview - Sigstore")

Resolves #249