### PR TITLE
Make search bar and results more accessible

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -8,7 +8,7 @@
   translation: "Search"
 
 - id: search-aria-label
-  translation: "Search this site. After typing, navigate to results with the tab key and select your result with the Enter key."
+  translation: "Press tab to navigate to search results"
 
 - id: 404-title
   translation: "404 — Page not found."

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -7,6 +7,9 @@
 - id: search-text
   translation: "Search"
 
+- id: search-aria-label
+  translation: "Search this site. After typing, navigate to results with the tab key and select your result with the Enter key."
+
 - id: 404-title
   translation: "404 — Page not found."
 

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -8,7 +8,7 @@
   translation: "Search"
 
 - id: search-aria-label
-  translation: "Press tab to navigate to search results"
+  translation: "Search. Press tab to navigate to search results"
 
 - id: 404-title
   translation: "404 — Page not found."

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -89,8 +89,8 @@
         <hr class="text-black-50 my-4 d-lg-none">
 
 	<div role="region"  aria-live="polite">
-          <form role="search" class="doks-search position-relative flex-grow-1 ms-lg-auto me-lg-2">
-          <input id="search" class="form-control is-search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-aria-label" }}" autocomplete="off">
+          <form class="doks-search position-relative flex-grow-1 ms-lg-auto me-lg-2">
+            <input id="search" class="form-control is-search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-aria-label" }}" autocomplete="off">
           <div id="suggestions" class="shadow bg-white rounded d-none"></div>
         </form>
       </div>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -89,8 +89,8 @@
         <hr class="text-black-50 my-4 d-lg-none">
 
 	<div role="region"  aria-live="polite">
-          <form class="doks-search position-relative flex-grow-1 ms-lg-auto me-lg-2">
-          <input id="search" class="form-control is-search" role="search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-aria-label" }}" autocomplete="off">
+          <form role="search" class="doks-search position-relative flex-grow-1 ms-lg-auto me-lg-2">
+          <input id="search" class="form-control is-search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-aria-label" }}" autocomplete="off">
           <div id="suggestions" class="shadow bg-white rounded d-none"></div>
         </form>
       </div>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -87,10 +87,13 @@
 
         {{ if $showFlexSearch -}}
         <hr class="text-black-50 my-4 d-lg-none">
-        <form class="doks-search position-relative flex-grow-1 ms-lg-auto me-lg-2">
-          <input id="search" class="form-control is-search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-text" }}" autocomplete="off">
+
+	<div role="region"  aria-live="polite">
+          <form class="doks-search position-relative flex-grow-1 ms-lg-auto me-lg-2">
+          <input id="search" class="form-control is-search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-aria-label" }}" autocomplete="off">
           <div id="suggestions" class="shadow bg-white rounded d-none"></div>
         </form>
+      </div>
         {{ end -}}
 
         <hr class="text-black-50 my-4 d-lg-none">

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -90,7 +90,7 @@
 
 	<div role="region"  aria-live="polite">
           <form class="doks-search position-relative flex-grow-1 ms-lg-auto me-lg-2">
-          <input id="search" class="form-control is-search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-aria-label" }}" autocomplete="off">
+          <input id="search" class="form-control is-search" role="search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-aria-label" }}" autocomplete="off">
           <div id="suggestions" class="shadow bg-white rounded d-none"></div>
         </form>
       </div>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -88,7 +88,7 @@
         {{ if $showFlexSearch -}}
         <hr class="text-black-50 my-4 d-lg-none">
 
-	<div role="region"  aria-live="polite">
+	<div role="region"  aria-live="assertive">
           <form class="doks-search position-relative flex-grow-1 ms-lg-auto me-lg-2">
             <input id="search" class="form-control is-search" type="search" placeholder="{{ i18n "search-text" }}" aria-label="{{ i18n "search-aria-label" }}" autocomplete="off">
           <div id="suggestions" class="shadow bg-white rounded d-none"></div>


### PR DESCRIPTION
## Changes

Added information on how to navigate to results in the aria-label attribute on the search bar

Added a new field to English internationalization with instructions on how to navigate to search results. This field will appear via the aria-label to screen reader users.

Added an enclosing div informing screen readers to update when the search results populate.

## Notes

Resolves #254 

Creating this issue as a draft for testing with other devices.