### PR TITLE
Changed aria label in main nav to resolve redundancy

### DIFF
--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 	<div class="row flex-xl-nowrap">
 		<div class="col-lg-5 col-xl-4 docs-sidebar{{ if ne .Site.Params.options.navbarSticky true }} docs-sidebar-top{{ end }} d-none d-lg-block">
-			<nav {{ if eq .Site.Params.menu.section.collapsibleSidebar false }}id="sidebar-default" {{ end }}class="docs-links" aria-label="Main navigation">
+			<nav {{ if eq .Site.Params.menu.section.collapsibleSidebar false }}id="sidebar-default" {{ end }}class="docs-links">
 				{{ partial "sidebar/docs-menu.html" . }}
 			</nav>
 		</div>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -6,7 +6,7 @@
 			</nav>
 		</div>
 		{{ if ne .Params.toc false -}}
-		<nav class="docs-toc{{ if ne .Site.Params.options.navbarSticky true }} docs-toc-top{{ end }} d-none d-xl-block col-xl-3" aria-label="Secondary navigation">
+		<nav class="docs-toc{{ if ne .Site.Params.options.navbarSticky true }} docs-toc-top{{ end }} d-none d-xl-block col-xl-3" aria-label="Secondary">
 			{{ partial "sidebar/docs-toc.html" . }}
 		</nav>
 		{{ end -}}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -9,7 +9,7 @@
 <div class="header-bar"></div>
 
 <header class="navbar navbar-expand-lg navbar-light doks-navbar">
-  <nav class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} flex-wrap flex-lg-nowrap" aria-label="Main">
+  <nav class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} flex-wrap flex-lg-nowrap" aria-label="Primary">
 
     <img alt="Sigstore logo" class="nav-image" src="{{ .Site.BaseURL }}/sigstore-logo.png" style="margin-right: 0.25em;height: 2em;">
     <a class="navbar-brand order-0" href="{{ .Site.BaseURL | relLangURL }}" aria-label="{{ .Site.Params.Title }}">
@@ -179,7 +179,7 @@
 
 {{ else if ne .CurrentSection .FirstSection -}}
 <!--
-<nav class="doks-subnavbar py-2 sticky-lg-top d-lg-none" aria-label="Secondary navigation">
+<nav class="doks-subnavbar py-2 sticky-lg-top d-lg-none" aria-label="Secondary">
   <div class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} d-flex align-items-lg-center">
     <span class="navbar-text ms-0">{{ .Section | humanize }}</span>
     <button class="btn doks-sidebar-toggle d-lg-none ms-auto order-3 collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#doks-docs-nav" aria-controls="doks-docs-nav" aria-expanded="false" aria-label="Toggle documentation navigation">

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -9,7 +9,7 @@
 <div class="header-bar"></div>
 
 <header class="navbar navbar-expand-lg navbar-light doks-navbar">
-  <nav class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} flex-wrap flex-lg-nowrap" aria-label="Main navigation">
+  <nav class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} flex-wrap flex-lg-nowrap" aria-label="Main">
 
     <img alt="Sigstore logo" class="nav-image" src="{{ .Site.BaseURL }}/sigstore-logo.png" style="margin-right: 0.25em;height: 2em;">
     <a class="navbar-brand order-0" href="{{ .Site.BaseURL | relLangURL }}" aria-label="{{ .Site.Params.Title }}">

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -28,7 +28,7 @@
       </div>
       <div class="offcanvas-body">
         <aside class="doks-sidebar mt-n3">
-          <nav id="doks-docs-nav" aria-label="Tertiary navigation">
+          <nav id="doks-docs-nav" aria-label="Tertiary">
             {{ partial "sidebar/docs-menu.html" . }}
           </nav>
         </aside>
@@ -171,7 +171,7 @@
 {{ if eq .Section "docs" -}}
 <div class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }}">
   <aside class="doks-sidebar">
-    <nav id="doks-docs-nav" class="collapse d-lg-none" aria-label="Tertiary navigation">
+    <nav id="doks-docs-nav" class="collapse d-lg-none" aria-label="Tertiary">
       {{ partial "sidebar/docs-menu.html" . }}
     </nav>
   </aside>
@@ -192,7 +192,7 @@
 
 <div class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }}">
   <aside class="doks-sidebar">
-    <nav id="doks-docs-nav" class="collapse d-lg-none" aria-label="Tertiary navigation">
+    <nav id="doks-docs-nav" class="collapse d-lg-none" aria-label="Tertiary">
       {{ partial "sidebar/docs-menu.html" . }}
     </nav>
   </aside>


### PR DESCRIPTION
## Description

The main navigation had an aria label that said main navigation. However, because it is a nav element, this results in hearing the word "navigation" twice with a screen reader. Changed "main navigation" to "main" to resolve this.

## Notes

Resolves #253

