### PR TITLE
Project docs left sidebar

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -1,46 +1,8 @@
-[[docs]]
+[[external]]
   name = "Cosign"
   weight = 20
   identifier = "cosign"
-  url = "/docs/cosign/"
-
-[[docs]]
-  name = "About"
-  weight = 10
-  identifier = "about"
-  url = "/docs/about/"
-
-[[docs]]
-  name = "Policy Controller"
-  weight = 30
-  identifier = "policy-controller"
-  url = "/docs/policy-controller/"
-
-[[docs]]
-  name = "Gitsign"
-  weight = 40
-  identifier = "gitsign"
-  url = "/docs/gitsign/"
-
-[[docs]]
-  name = "Rekor"
-  weight = 50
-  identifier = "rekor"
-  url = "/docs/rekor/"
-
-[[docs]]
-  name = "Get Involved"
-  weight = 60
-  identifier = "get_involved"
-  url = "/docs/get_involved/"
-
-[[docs]]
-  name = "Help"
-  weight = 70
-  identifier = "help"
-  url = "/docs/help/"
-
-
+  url = "https://github.com/sigstore/cosign/tree/main/doc"
 
 # [[main]]
 #   name = "Docs"

--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -1,8 +1,26 @@
 [[external]]
   name = "Cosign"
-  weight = 20
+  weight = 10
   identifier = "cosign"
   url = "https://github.com/sigstore/cosign/tree/main/doc"
+
+[[external]]
+  name = "Fulcio"
+  weight = 20
+  identifier = "fulcio"
+  url = "https://github.com/sigstore/fulcio/tree/main/docs"
+
+[[external]]
+  name = "Gitsign"
+  weight = 30
+  identifier = "gitsign"
+  url = "https://github.com/sigstore/gitsign/tree/main/docs"
+
+[[external]]
+  name = "Policy Controller"
+  weight = 40
+  identifier = "policy-controller"
+  url = "https://github.com/sigstore/policy-controller/blob/main/docs/api-types/index.md"
 
 # [[main]]
 #   name = "Docs"

--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -6,7 +6,7 @@
 
   {{- range site.Menus.external }}
 
-  {{ $NewPage := dict "Title" .Name "Permalink" .ConfiguredURL }}
+  {{ $NewPage := dict "TargetBlank" true "Title" .Name "Permalink" .ConfiguredURL }}
     {{ $ExternalDocsPages = $ExternalDocsPages | append $NewPage }}
   
 {{ end }}
@@ -60,8 +60,7 @@
                 </li>
               {{ else }}
                 {{ $active := in $currentPage.RelPermalink .RelPermalink }}
-                <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .Permalink }}">
-
+               <li><a class="docs-link rounded{{ if $active }} active{{ end }}" href="{{ .Permalink }}" {{ if isset . "TargetBlank" }}target="_blank"{{ end }}>
 		  {{ partial "partials/sidebar/menu-item.html" . }}
 
 		</a></li>

--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -2,8 +2,22 @@
 <ul class="list-unstyled collapsible-sidebar">
   {{ $currentPage := . -}}
 
+  {{ $ExternalDocsPages := slice }}
+
+  {{- range site.Menus.external }}
+
+  {{ $NewPage := dict "Title" .Name "Permalink" .ConfiguredURL }}
+    {{ $ExternalDocsPages = $ExternalDocsPages | append $NewPage }}
+  
+{{ end }}
+
+  {{ $ExternalSiteSection := dict "Title" "Project Documentation" "Pages" $ExternalDocsPages }}
+  
+  {{ $Sections := site.Sections | append $ExternalSiteSection }}
+
+
   <!-- This changed from Doks default to reflect no "docs" section folder -->
-    {{ range site.Sections }}
+    {{ range $Sections }}
       {{ $active := in $currentPage.RelPermalink .RelPermalink }}
       <li class="mb-1">
         <button class="btn btn-toggle align-items-center rounded collapsed" data-bs-toggle="collapse" data-bs-target="#section-{{ md5 .Title }}" aria-expanded="{{ if $active }}true{{ else }}false{{ end }}">


### PR DESCRIPTION
## Overview

This PR adds items to the left sidebar under the heading "Project Documentation." These items lead to external docs in the respective project repositories.

## Implementation

Because Hugo generates the left sidebar from metadata in the content folder (one of the three main approaches to generating menus in Hugo), adding a section that leads to external sites required writing new template logic.

This PR removes vestigial menu metadata from the menus.toeml config file and adds a new menu, "external." This menu is referenced directly in the sidebar partial when building the sidebar. Because menu items created this way have a different structure from menu items created automatically (thanks, Hugo), the logic added in this PR takes menu items defined in the config and modifies them to look like automaticly generated menu items. A new section is then created, the new pages are added to the section metadata, and the new section is appended to the site's automatically generated sections.

## Adding New Items

To edit the items in this new menu heading, future contributors should edit the toeml in `config/_default/menus/menus.en.toml`.

## Notes

This PR resolves #250