### PR TITLE
Updated the Go version needed to a version that works.

### DIFF
--- a/content/en/system_config/installation.md
+++ b/content/en/system_config/installation.md
@@ -5,9 +5,9 @@ title: Installation
 weight: 950
 ---
 
-## With Go 1.19+
+## With Go 1.20+
 
-If you have Go 1.19+, you can directly install Cosign by downloading the Cosign binary and running:
+If you have Go 1.20+, you can directly install Cosign by running:
 
 ```bash
 go install github.com/sigstore/cosign/v2/cmd/cosign@latest


### PR DESCRIPTION
Fixes #271

#### Summary

When following the install instructions they suggest using Go 1.19+ but you need to use 1.20+ or the instructions won't work.

And you don't need to download the binary first. Just run the `go install ...` command

#### Release Note

NONE

#### Documentation

This is a PR to docs!
