### PR TITLE
docs: Add Documentation for --yes Flag in Blob Signing

### DIFF
--- a/content/en/signing/signing_with_blobs.md
+++ b/content/en/signing/signing_with_blobs.md
@@ -101,5 +101,5 @@ $ cosign sign gcr.io/user/demo/artifact
 In situations where automated signing is required, such as within CI/CD pipelines, the --yes flag becomes essential. This flag, when used with signing commands, bypasses any confirmation prompts, enabling a smooth, uninterrupted signing process. This is particularly crucial in automated environments where manual input isn't feasible. The --yes flag ensures that your signing operations can proceed without manual intervention, maintaining the efficiency and speed of your automated workflows.
 
 ```
-cosign sign --yes -key cosign.key myregistry/myimage:latest
+cosign sign-blob --yes -key cosign.key myregistry/myimage:latest
 ```

--- a/content/en/signing/signing_with_blobs.md
+++ b/content/en/signing/signing_with_blobs.md
@@ -96,3 +96,10 @@ You can sign it with the normal `cosign sign` command and flags:
 ```shell
 $ cosign sign gcr.io/user/demo/artifact
 ```
+## Non-Interactive Signing with the Yes Flag
+
+In situations where automated signing is required, such as within CI/CD pipelines, the --yes flag becomes essential. This flag, when used with signing commands, bypasses any confirmation prompts, enabling a smooth, uninterrupted signing process. This is particularly crucial in automated environments where manual input isn't feasible. The --yes flag ensures that your signing operations can proceed without manual intervention, maintaining the efficiency and speed of your automated workflows.
+
+```
+cosign sign --yes -key cosign.key myregistry/myimage:latest
+```

--- a/content/en/signing/signing_with_blobs.md
+++ b/content/en/signing/signing_with_blobs.md
@@ -98,7 +98,7 @@ $ cosign sign gcr.io/user/demo/artifact
 ```
 ## Non-Interactive Signing with the Yes Flag
 
-In situations where automated signing is required, such as within CI/CD pipelines, the --yes flag becomes essential. This flag, when used with signing commands, bypasses any confirmation prompts, enabling a smooth, uninterrupted signing process. This is particularly crucial in automated environments where manual input isn't feasible. The --yes flag ensures that your signing operations can proceed without manual intervention, maintaining the efficiency and speed of your automated workflows.
+In situations where automated signing is required, such as within CI/CD pipelines, the `--yes` flag becomes essential. This flag, when used with signing commands, bypasses any confirmation prompts, enabling a smooth, uninterrupted signing process. This is particularly crucial in automated environments where manual input isn't feasible. The `--yes` flag ensures that your signing operations can proceed without manual intervention, maintaining the efficiency and speed of your automated workflows.
 
 ```
 cosign sign-blob --yes -key cosign.key myregistry/myimage:latest


### PR DESCRIPTION
**Description:**

This PR updates the documentation for blob signing in the Cosign project. Specifically, it adds information about the --yes flag, which allows users to bypass confirmation prompts during the signing process.

**Changes Made:**
Added a new section titled "Non-Interactive Signing with the Yes Flag" in signing_with_blobs.md.
Provided a detailed description of the --yes flag and its usage.
Included a real-world example to demonstrate the use of the flag in CI/CD pipelines.

**Importance of This Update:**
The inclusion of the --yes flag in the documentation addresses a critical need for automated, non-interactive signing in CI/CD environments. As experienced personally, the absence of this information can lead to challenges and failures in automated pipelines due to unexpected interactive prompts. This update will facilitate smoother and more efficient signing processes for users relying on automation.

