### PR TITLE
Fix accessibility issues in header

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -100,14 +100,14 @@
         <ul class="nav flex-column flex-lg-row">
           {{ range .Site.Menus.social -}}
             <li class="nav-item">
-              <a class="nav-link social-link" href="{{ .URL | relURL }}">{{ .Pre | safeHTML }}<small class="ms-2 d-lg-none">{{ .Name | safeHTML }}</small></a>
+              <a class="nav-link social-link" href="{{ .URL | relURL }}" aria-label="{{ .Name | safeHTML }}">{{ .Pre | safeHTML }}<small class="ms-2 d-lg-none">{{ .Name | safeHTML }}</small></a>
             </li>
           {{ end -}}
         </ul>
 
         {{ if .Site.Params.options.darkMode -}}
         <hr class="text-black-50 my-4 d-lg-none">
-        <button id="mode" class="btn btn-link" type="button" aria-label="Toggle user interface mode">
+        <button id="mode" class="btn btn-link" type="button" aria-label="Toggle light/dark mode">
           <span class="toggle-dark"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-moon"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg></span>
           <span class="toggle-light"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-sun"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg></span>
         </button>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -11,9 +11,9 @@
 <header class="navbar navbar-expand-lg navbar-light doks-navbar">
   <nav class="container-{{ if .Site.Params.options.fullWidth }}fluid{{ else }}xxl{{ end }} flex-wrap flex-lg-nowrap" aria-label="Primary">
 
+
+    <a class="navbar-brand order-0" href="{{ .Site.BaseURL | relLangURL }}" aria-label="{{ .Site.Params.Title }} Home">
     <img alt="Sigstore logo" class="nav-image" src="{{ .Site.BaseURL }}/sigstore-logo.png" style="margin-right: 0.25em;height: 2em;">
-    <a class="navbar-brand order-0" href="{{ .Site.BaseURL | relLangURL }}" aria-label="{{ .Site.Params.Title }}">
-      {{ .Site.Params.Title }}
     </a>
 
     {{ if (in .Site.Params.sections.sectionNav .Section) -}}


### PR DESCRIPTION
# Overview

This PR resolves two issues. First, the Sigstore logo was not properly nested with a link to the home page, creating an issue for screen readers (the link and the logo were registering as separate elements next to each other rather than one element). Second, the social buttons were improperly labeled, probably due to the anchor text being hidden in CSS.

## Resolution

1. The Sigstore logo has been placed inside the link to the home page. This shouldn't change the behavior for those not using a screen reader but should be better for screen reader users.
2. An aria-label has been included in the Hugo logic for the header that generates the social buttons.
3. I renamed the label for the dark mode toggle. Previously, it said "toggle user interface mode," which could mean anything. Now it says "toggle dark/light mode."

## Notes

Resolves #275
Resolves #277