### PR TITLE
Docs: Fix the rpm binary download release break

### DIFF
--- a/content/en/system_config/installation.md
+++ b/content/en/system_config/installation.md
@@ -27,8 +27,8 @@ sudo chmod +x /usr/local/bin/cosign
 
 # rpm
 LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | grep tag_name | cut -d : -f2 | tr -d "v\", ")
-curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}.x86_64.rpm"
-sudo rpm -ivh cosign-${LATEST_VERSION}.x86_64.rpm
+curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}-1.x86_64.rpm"
+sudo rpm -ivh cosign-${LATEST_VERSION}-1.x86_64.rpm
 
 # dkpg
 LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | grep tag_name | cut -d : -f2 | tr -d "v\", ")


### PR DESCRIPTION
#### Summary

Resolve the issue that was causing break in downloading the cosign rpm release file.

#### Release Note

NONE

#### Documentation

This PR updates the Docs

Resolves #273 
