### PR TITLE
Docs: Fix the Table Content Overflow Issue

### DIFF
--- a/assets/scss/components/_tables.scss
+++ b/assets/scss/components/_tables.scss
@@ -1,5 +1,5 @@
 table {
   @extend .table;
-
+  font-size: x-small;
   margin: 3rem 0;
 }


### PR DESCRIPTION
#### Summary

Change the font-size of tables to avoid overflow of content in tables

#### Release Note

NONE

#### Documentation

This PR Solves the bug

Resolves #107 
