### PR TITLE
Add link to Swagger docs to main menu

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -22,6 +22,12 @@
   identifier = "policy-controller"
   url = "https://github.com/sigstore/policy-controller/blob/main/docs/api-types/index.md"
 
+[[swagger]]
+  name = "OpenAPI Specification"
+  weight = 50
+  identifier = "swagger"
+  url = "https://www.sigstore.dev/swagger/"
+
 # [[main]]
 #   name = "Docs"
 #   url = "/docs/about/overview/"

--- a/layouts/partials/sidebar/auto-collapsible-menu.html
+++ b/layouts/partials/sidebar/auto-collapsible-menu.html
@@ -15,6 +15,15 @@
   
   {{ $Sections := site.Sections | append $ExternalSiteSection }}
 
+  {{ $SwaggerDocsPages := slice }}
+  {{- range site.Menus.swagger }}
+  {{ $NewPage := dict "TargetBlank" true "Title" .Name "Permalink" .ConfiguredURL }}
+    {{ $SwaggerDocsPages = $SwaggerDocsPages | append $NewPage }}
+  {{ end }}
+  {{ $SwaggerSection := dict "Title" "API Reference" "Pages" $SwaggerDocsPages }}
+
+  {{ $Sections = $Sections | append $SwaggerSection }}
+
 
   <!-- This changed from Doks default to reflect no "docs" section folder -->
     {{ range $Sections }}


### PR DESCRIPTION
The HTTP API reference is not linked through the docs site so it's not clear to a newcomer to Sigstore that one actually exists. This change adds a link on the main menu out to the auto-generated Swagger site so that it is easily discoverable.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
n/a