### PR TITLE
Fix RPM installation URL to include release

### DIFF
--- a/content/en/system_config/installation.md
+++ b/content/en/system_config/installation.md
@@ -27,7 +27,7 @@ sudo chmod +x /usr/local/bin/cosign
 
 # rpm
 LATEST_VERSION=$(curl https://api.github.com/repos/sigstore/cosign/releases/latest | grep tag_name | cut -d : -f2 | tr -d "v\", ")
-curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}.x86_64.rpm"
+curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-${LATEST_VERSION}-1.x86_64.rpm"
 sudo rpm -ivh cosign-${LATEST_VERSION}.x86_64.rpm
 
 # dkpg


### PR DESCRIPTION
Closes #286

#### Summary
Fix RPM installation URL was missing release part of RPM file name

#### Release Note
NONE

#### Documentation
NONE