### PR TITLE
Revert "document `--ca-roots` and `--ca-intermediates`  flags for 'cosign verify'"

### DIFF
--- a/content/en/verifying/verify.md
+++ b/content/en/verifying/verify.md
@@ -80,22 +80,12 @@ $ cosign verify --certificate cosign.crt --certificate-chain chain.crt user/demo
 ```
 
 ## Verify image with user-provided trusted chain
-Verify image with the provided certificate chain(s) and identity parameters (intended for
-"bring your own PKI" use cases).
-* with a single certificate chain file - which may contain one or several intermediate
-certificates followed by the root CA certificate - use the `--certificate-chain` parameter:
+Verify image with the provided certificate chain and identity parameters (intended for
+a "bring your own PKI" use case):
+
 ```shell
 $ cosign verify --certificate-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com user/demo
 ```
-* with a certificate bundle PEM file containing several CA roots and (optionally)
-intermediate certificates, use the `--ca-roots` parameter together with `--ca-intermediates`:
-```shell
-$ cosign verify --ca-roots ca-roots.pem --ca-intermediates ca-intermediates \
-  --certificate-oidc-issuer https://issuer.example.com \
-  --certificate-identity foo@example.com user/demo
-```
-
-The `--ca-roots` and `--ca-intermediates` flags are mutually exclusive with `--certificate-chain`.
 
 ## Verify an image on the transparency log
 


### PR DESCRIPTION
Reverts sigstore/docs#291

Feature not yet implemented