### PR TITLE
Fix the local verification using certificates docs.

### DIFF
--- a/content/en/verifying/verify.md
+++ b/content/en/verifying/verify.md
@@ -76,7 +76,7 @@ $ cosign verify --key cosign.pub --local-image PATH/to/user/demo
 Verify image with local certificate and local certificate chain:
 
 ```shell
-$ cosign verify --certificate cosign.crt --certificate-chain chain.crt user/demo
+$ cosign verify --certificate cosign.crt --certificate-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com user/demo
 ```
 
 ## Verify image with user-provided trusted chain


### PR DESCRIPTION
#### Summary

Verification using certificates requires also the validation of the certificate's issuer and identity.

The previous example was missing those flag values, which have been added now.

Fixes https://github.com/sigstore/cosign/issues/3671.

#### Release Note

Fixed the documentation for local verification using certificates.

#### Documentation

