### PR TITLE
Added navigation to hamburger menu

### DIFF
--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -491,3 +491,10 @@ button#doks-versions {
     padding-left: 0.5rem;
   }
 }
+
+// Hide sidebar appearing inside hamburger menu
+// on mobile devices
+@include media-breakpoint-up(lg) {
+    .sidebar-mobile {
+        display: none;
+    }}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -162,6 +162,11 @@
           </ul>
         </div>
         {{ end -}}
+
+        <div class="sidebar-mobile">
+          {{ partial "sidebar/auto-collapsible-menu.html" . }}
+        </div>
+
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary

Adds an instance of the navigation sidebar to the hamburger menu on mobile devices. There is currently no navigation menu on small or medium screens.

## Consideration and Testing

To see the change, view the site's hamburger menu (click the three lines in top right that appear on small or medium screen sizes). There should be a navigation menu at the bottom of the popout panel.

The code here adds a second instance of the sidebar to the page, which is not ideal. It is hidden on large and up screens using display:none, just as the current sidebar is hidden on displays of medium or below. I don't like that this adds a second instance of the sidebar for page load, etc., but I don't see a way to work the current sidebar into the hanburger menu without this approach.

## Notes

Resolves #304
