### PR TITLE
document --ca-roots and --ca-intermediates flags for 'cosign verify'

### DIFF
--- a/content/en/verifying/verify.md
+++ b/content/en/verifying/verify.md
@@ -87,18 +87,15 @@ certificates followed by the root CA certificate - use the `--certificate-chain`
 ```shell
 $ cosign verify --certificate-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com user/demo
 ```
-* with a certificate bundle PEM file containing several CA roots (but without
-intermediate certificate), use the `--ca-roots` parameter:
+* with a certificate bundle PEM file containing several CA roots and (optionally)
+intermediate certificates, use the `--ca-roots` parameter together with `--ca-intermediates`:
 ```shell
-$ cosign verify --ca-roots ca-roots.pem --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com user/demo
+$ cosign verify --ca-roots ca-roots.pem --ca-intermediates ca-intermediates \
+  --certificate-oidc-issuer https://issuer.example.com \
+  --certificate-identity foo@example.com user/demo
 ```
 
-The `--ca-roots` and `--certificate-chain` flags are mutually exclusive.
-
-Note that the hypothetical use case of "multiple chains with multiple CA roots and intermediate
-certificates" is not yet supported.  There are plans to add the `--ca-intermediates` parameter
-(see [issue #3462](https://github.com/sigstore/cosign/issues/3462)).  If you need this,
-please open an issue and mention it on the Sigstore #cosign Slack.
+The `--ca-roots` and `--ca-intermediates` flags are mutually exclusive with `--certificate-chain`.
 
 ## Verify an image on the transparency log
 

--- a/content/en/verifying/verify.md
+++ b/content/en/verifying/verify.md
@@ -80,12 +80,25 @@ $ cosign verify --certificate cosign.crt --certificate-chain chain.crt --certifi
 ```
 
 ## Verify image with user-provided trusted chain
-Verify image with the provided certificate chain and identity parameters (intended for
-a "bring your own PKI" use case):
-
+Verify image with the provided certificate chain(s) and identity parameters (intended for
+"bring your own PKI" use cases).
+* with a single certificate chain file - which may contain one or several intermediate
+certificates followed by the root CA certificate - use the `--certificate-chain` parameter:
 ```shell
 $ cosign verify --certificate-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com user/demo
 ```
+* with a certificate bundle PEM file containing several CA roots (but without
+intermediate certificate), use the `--ca-roots` parameter:
+```shell
+$ cosign verify --ca-roots ca-roots.pem --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com user/demo
+```
+
+The `--ca-roots` and `--certificate-chain` flags are mutually exclusive.
+
+Note that the hypothetical use case of "multiple chains with multiple CA roots and intermediate
+certificates" is not yet supported.  There are plans to add the `--ca-intermediates` parameter
+(see [issue #3462](https://github.com/sigstore/cosign/issues/3462)).  If you need this,
+please open an issue and mention it on the Sigstore #cosign Slack.
 
 ## Verify an image on the transparency log
 

--- a/content/en/verifying/verify.md
+++ b/content/en/verifying/verify.md
@@ -80,15 +80,20 @@ $ cosign verify --certificate cosign.crt --certificate-chain chain.crt --certifi
 ```
 
 ## Verify image with user-provided trusted chain
+
 Verify image with the provided certificate chain(s) and identity parameters (intended for
 "bring your own PKI" use cases).
+
 * with a single certificate chain file - which may contain one or several intermediate
 certificates followed by the root CA certificate - use the `--certificate-chain` parameter:
+
 ```shell
 $ cosign verify --certificate-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com user/demo
 ```
+
 * with a certificate bundle PEM file containing several CA roots and (optionally)
 intermediate certificates, use the `--ca-roots` parameter together with `--ca-intermediates`:
+
 ```shell
 $ cosign verify --ca-roots ca-roots.pem --ca-intermediates ca-intermediates \
   --certificate-oidc-issuer https://issuer.example.com \


### PR DESCRIPTION
#### Summary
NB - please merge only AFTER the corresponding code PR https://github.com/sigstore/cosign/pull/3464 is merged ❗ 

Redux of https://github.com/sigstore/docs/pull/291 reverted in https://github.com/sigstore/docs/pull/298.
Document the new `--ca-roots` and `--ca-intermediates` flags for `cosign verify`.

Related to sigstore/cosign https://github.com/sigstore/cosign/pull/3464 and its issue https://github.com/sigstore/cosign/issues/3462. 
Document the new 'cosign verify' --ca-roots flag 
and its difference to the --certificate-chain flag.
List the supported and currently unsupported use cases (single/multiple CA(s), intermediate CAs).


#### Release Note
* New features and improvements, including behavioural changes, UI changes and CLI changes
- `cosign verify`: added new `-ca-roots` and `--ca-intermediates` flags to use a certificate bundle PEM file with multiple CA root and optionally intermediate certificates

#### Documentation
N/A (this PR is the documentation change)