### PR TITLE
Update rekor sharding guide

### DIFF
--- a/content/en/logging/sharding.md
+++ b/content/en/logging/sharding.md
@@ -47,7 +47,7 @@ Follow these steps to shard the log:
 
     ```bash
     CURRENT_TREE_ID=$(rekor-cli loginfo --format json | jq -r .TreeID)
-    CURRENT_SHARD_LENGTH=$(rekor-cli loginfo --format json | jq -r .TreeSize)
+    CURRENT_SHARD_LENGTH=$(rekor-cli loginfo --format json | jq -r .ActiveTreeSize)
     ```
 
 3. Connect to the production cluster. Port-forward the running `trillian_logserver` container and run the [createtree](https://github.com/google/trillian/blob/master/cmd/createtree/main.go) script.
@@ -58,6 +58,7 @@ This will create a new Merkle Tree which will become the new active shard.
     # This is the Tree ID of the new active shard
     NEW_TREE_ID=$(createtree --admin_server localhost:8090)
     ```
+    > **Note:** sigstore helm charts use port 8091 for gRPC
 
 4. Update the Rekor `sharding-config` ConfigMap with details of the inactive shard:
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Fixes #314 

The rekor sharding [guide](https://docs.sigstore.dev/logging/sharding/#how-do-i-shard-the-rekor-log) needs to be updated to account for the https://github.com/sigstore/rekor/pull/864 introduced in Rekor and a note for users to use Trillian port 8091 for gRPC when using Sigstore helm charts.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
  * Rename `TreeSize` to `ActiveTreeSize` introduced as a breaking change in rekor PR #864
  * Add a note sigstore helm chart making use of port 8091 for gRPC

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
This will require an update to documentation for rekor sharding guide: https://docs.sigstore.dev/logging/sharding/