### PR TITLE
Adding section for language clients.

### DIFF
--- a/content/en/language_clients/_index.html
+++ b/content/en/language_clients/_index.html
@@ -1,0 +1,11 @@
+---
+type: docs
+title: "Language Clients"
+description: "Language Clients"
+lead: "Language Clients"
+date: 2024-10-06T08:49:15+00:00
+lastmod: 2024-10-06T08:49:15+00:00
+draft: false
+images: []
+weight: 20
+---

--- a/content/en/language_clients/language_client_overview.md
+++ b/content/en/language_clients/language_client_overview.md
@@ -1,0 +1,19 @@
+---
+type: docs
+category: Language Clients
+title: Language Client Overview
+weight: 5
+---
+
+Sigstore uses [cosign](../../cosign/signing/overview) to sign and verify packages by default, but you can opt to use a language specific client instead.
+
+Sigstore has clients for the following language ecosystems:
+
+- [Python](https://github.com/sigstore/sigstore-python#sigstore-python)
+- [Rust](https://github.com/sigstore/sigstore-rs#features)
+- [Ruby](https://github.com/sigstore/sigstore-ruby#sigstore)
+- [JavaScript](https://github.com/sigstore/sigstore-js#sigstore-js---)
+- [Java](https://github.com/sigstore/sigstore-java#sigstore-java)
+- [Go](https://github.com/sigstore/sigstore-go#sigstore-go)
+
+Currently, language client documentation is hosted in the individual project repositories. This documentation is being migrated to the general sigstore docs.

--- a/content/en/quickstart/quickstart-cosign.md
+++ b/content/en/quickstart/quickstart-cosign.md
@@ -14,7 +14,7 @@ Join us on our [Slack channel](https://sigstore.slack.com/). (Need an [invite](h
 
 Cosign is a command line utility that is used to sign software artifacts and verify signatures using Sigstore.
 
-Sigstore has a number of language specific clients (like [sigstore-python](https://github.com/sigstore/sigstore-python)). These clients are SDKs that you can use to build custom tooling. Although a number of the clients include a basic CLI, Cosign is the recommended tool for signing and verifying.  
+Sigstore has a number of [language specific clients](../../language_clients/language_client_overview) that you can use to build custom tooling. Although a number of the clients include a basic CLI, Cosign is the recommended tool for signing and verifying.
 
 This quickstart will walk you through how to sign and verify a blob and a container.
 


### PR DESCRIPTION
#### Summary
Addresses #324 

This work creates a "Language Client" section in the docs. It links to relevant docs for each language client, which will be updated as documentation migrates.


#### Release Note
None
