### PR TITLE
Adding rust client information to docs

### DIFF
--- a/content/en/language_clients/language_client_overview.md
+++ b/content/en/language_clients/language_client_overview.md
@@ -10,7 +10,7 @@ Sigstore uses [cosign](../../cosign/signing/overview) to sign and verify package
 Sigstore has clients for the following language ecosystems:
 
 - [Python](../python/overview)
-- [Rust](https://github.com/sigstore/sigstore-rs#features)
+- [Rust](../rust/overview)
 - [Ruby](https://github.com/sigstore/sigstore-ruby#sigstore)
 - [JavaScript](https://github.com/sigstore/sigstore-js#sigstore-js---)
 - [Java](https://github.com/sigstore/sigstore-java#sigstore-java)

--- a/content/en/language_clients/rust/_index.html
+++ b/content/en/language_clients/rust/_index.html
@@ -1,0 +1,11 @@
+---
+type: docs
+title: "Rust"
+description: "Rust Language Client"
+lead: "Rust Language Client"
+date: 2024-10-06T08:49:15+00:00
+lastmod: 2024-10-06T08:49:15+00:00
+draft: false
+images: []
+weight: 80
+---

--- a/content/en/language_clients/rust/overview.md
+++ b/content/en/language_clients/rust/overview.md
@@ -7,11 +7,11 @@ weight: 5
 
 [`sigstore`](https://crates.io/crates/sigstore) is a crate designed to interact with Sigstore architecture.
 
-This crate is under active development, but will not be considered stable until the 1.0 release.
+**This crate is under active development, and will not be considered stable until the [1.0 release](https://github.com/sigstore/sigstore-rs/issues/274).**
 
 ## Features
 
-- Cosign sign and verify
+- Container and binary signing and verification
 - Fulcio integration including an OpenID Connect API
 - All Rekor client APIs can be leveraged to interact with the transparency log
 - Cryptographic key management
@@ -27,6 +27,8 @@ cargo add sigstore
 Or add the following to your Cargo.toml:
 
 `sigstore = "0.10.0"`
+
+Current release information is available [here](https://github.com/sigstore/sigstore-rs/releases).
 
 ## Example
 

--- a/content/en/language_clients/rust/overview.md
+++ b/content/en/language_clients/rust/overview.md
@@ -1,0 +1,34 @@
+---
+type: docs
+category: Rust
+title: Rust Client Overview
+weight: 5
+---
+
+[`sigstore`](https://crates.io/crates/sigstore) is a crate designed to interact with Sigstore architecture.
+
+This crate is under active development, but will not be considered stable until the 1.0 release.
+
+## Features
+
+- Cosign sign and verify
+- Fulcio integration including an OpenID Connect API
+- All Rekor client APIs can be leveraged to interact with the transparency log
+- Cryptographic key management
+
+
+## Installation
+
+Run the following command in your project directory:
+
+```console
+cargo add sigstore
+```
+
+Or add the following to your Cargo.toml:
+
+`sigstore = "0.10.0"`
+
+## Example
+
+Numerous examples are provided in the [project repository](https://github.com/sigstore/sigstore-rs/tree/main/examples), including a [simple signing example](https://github.com/sigstore/sigstore-rs/tree/main/examples/cosign/sign) and a number of examples interacting with the [Rekor transparency log](https://github.com/sigstore/sigstore-rs/tree/main/examples/rekor).

--- a/content/en/language_clients/rust/overview.md
+++ b/content/en/language_clients/rust/overview.md
@@ -16,7 +16,6 @@ This crate is under active development, but will not be considered stable until 
 - All Rekor client APIs can be leveraged to interact with the transparency log
 - Cryptographic key management
 
-
 ## Installation
 
 Run the following command in your project directory:


### PR DESCRIPTION
#### Summary
Partially addresses #324 by adding information on the Rust Client. 

#### Release Note
None
