### PR TITLE
mention 'cosign attest' and 'cosign blob-attest' in TSA section

### DIFF
--- a/content/en/cosign/verifying/timestamps.md
+++ b/content/en/cosign/verifying/timestamps.md
@@ -52,7 +52,7 @@ cosign verify --timestamp-certificate-chain ts_chain.pem <artifact>
 
 ### mTLS connection to the TSA server
 
-`cosign sign` and `cosign sign-blob` accept several additional optional parameters to pass the CA certificate of
+`cosign sign`, `sign-blob`, `attest` and `attest-blob` commands accept several additional optional parameters to pass the CA certificate of
 the TSA server in cases where it uses a custom CA, or to establish a mutual TLS connection to the TSA server:
 ```
     --timestamp-client-cacert='':


### PR DESCRIPTION
#### Summary

NB - the related https://github.com/sigstore/cosign/pull/4079 has been merged.

Expand the list of commands that support the mTLS and custom CA TSA parameters to include `cosign attest` and `cosign blob-attest`. Related to https://github.com/sigstore/cosign/pull/4079 and its issue
https://github.com/sigstore/cosign/issues/4078.

Similar to the previous https://github.com/sigstore/docs/pull/239 *for `cosign sign-blob`).

#### Release Note
Documentation change - the release notes are in the sigstore/cosign PR.

#### Documentation
The change itself is a minor documentation update.
