### PR TITLE
Add support statement for the Quay registry

### DIFF
--- a/content/en/cosign/system_config/registry_support.md
+++ b/content/en/cosign/system_config/registry_support.md
@@ -22,6 +22,7 @@ Today, Cosign has been tested and works against the following registries:
 * Digital Ocean Container Registry
 * Sonatype Nexus Container Registry
 * Alibaba Cloud Container Registry
+* Quay.io and Project Quay Container Registry
 
 We aim for wide registry support. To sign images in registries which do not yet fully support OCI media types, one may need to use `COSIGN_DOCKER_MEDIA_TYPES` to fall back to legacy equivalents. For example:
 


### PR DESCRIPTION
#### Summary
We've been extensively using cosign / SigStore-style signature and attestation attachment features with both quay.io as well as Project Quay. This change adds it to the list of compatible registries, as Quay has also adopted the OCI 1.1 feature set.
This closes #372.

#### Release Note

NONE
