### PR TITLE
docs: Fix a minor typo in verification-cheat-sheet.md

### DIFF
--- a/content/en/quickstart/verification-cheat-sheet.md
+++ b/content/en/quickstart/verification-cheat-sheet.md
@@ -8,7 +8,7 @@ weight: 20
 
 ## Identity Verification Cheat Sheet
 
-### Verying identity from OIDC issuers
+### Verifying identity from OIDC issuers
 
 To verify a signature created with an OIDC issuer, you need to know the following:
 


### PR DESCRIPTION

#### Summary
This change fixes a minor typo (Fix `Verying` -> `Verifying`) in `verification-cheat-sheet.md`.


#### Release Note
NONE

#### Documentation
No, this change just updates the documentation.
