### PR TITLE
Fix typographical errors

### DIFF
--- a/content/en/quickstart/quickstart-ci.md
+++ b/content/en/quickstart/quickstart-ci.md
@@ -13,7 +13,7 @@ Join us on our [Slack channel](https://sigstore.slack.com/). (Need an [invite](h
 Sigstore provides two GitHub Actions that make it easy to integrate signing and verifying into your CI system.
 
 - The [`gh-action-sigstore-python` GitHub Action](https://github.com/sigstore/gh-action-sigstore-python) provides the easiest way to generate Sigstore signatures within your CI system. It uses the Sigstore Python language client ([`sigstore-python`](https://github.com/sigstore/sigstore-python)), but can be used to generate Sigstore signatures regardless of your project's language.
-- The [`consign-installer` GitHub Action](https://github.com/marketplace/actions/cosign-installer) installs cosign into your GitHub Action environment, making all features of Cosign available to be used within your CI System.
+- The [`cosign-installer` GitHub Action](https://github.com/marketplace/actions/cosign-installer) installs cosign into your GitHub Action environment, making all features of Cosign available to be used within your CI System.
 
 This quickstart will walk you through the use of the `gh-action-sigstore-python` to [sign](#signing-files-using-your-ci-system) files, which is the quickest way to integrate Sigstore into your CI system. This quickstart also includes a [walkthrough](#using-cosign-within-your-ci-system) of using basic Cosign features in your workflows.
 
@@ -70,10 +70,10 @@ The `gh-action-sigstore-python` GitHub Action includes an option to verify your 
 
 ## Using Cosign within your CI system
 
-If you need functionality beyond simple signing of files and blobs, you can use the [`consign-installer` GitHub Action](https://github.com/marketplace/actions/cosign-installer) to [integrate Sigstore into your CI system](#installing-cosign-on-your-ci). This quickstart covers:
+If you need functionality beyond simple signing of files and blobs, you can use the [`cosign-installer` GitHub Action](https://github.com/marketplace/actions/cosign-installer) to [integrate Sigstore into your CI system](#installing-cosign-on-your-ci). This quickstart covers:
 
 - How to [sign and verify a container image](#signing-and-verifying-a-container-image) using your CI system
-- How to [sign](#signing-a-blob) and [verify](#verifying-a-blob) a blob using `consign-installer`
+- How to [sign](#signing-a-blob) and [verify](#verifying-a-blob) a blob using `cosign-installer`
 
 ### Installing Cosign on your CI
 


### PR DESCRIPTION
#### Summary

This change corrects several typographical errors where the [cosign-installer](http://github.com/sigstore/cosign-installer) GitHub Action is mistakenly referred to as `consign-installer`.

#### Release Note

NONE

#### Documentation

This change updates the documentation in the Markdown file `quickstart-ci.md`.