### PR TITLE
Update references to python action

### DIFF
--- a/content/en/certificate_authority/oidc-in-fulcio.md
+++ b/content/en/certificate_authority/oidc-in-fulcio.md
@@ -42,7 +42,7 @@ When verifying a signature generated through a workflow on GitHub, you can expec
 * **certificate-oidc-issuer**: https://token.actions.githubusercontent.com
 * **certificate-identity**: https://github.com/USERNAME/REPOSITORY_NAME/.github/workflows/WORKFLOW_NAME@refs/heads/BRANCH_NAME
 
-Sigstore currently offers two different GitHub Actions ([`cosign-installer`](https://github.com/marketplace/actions/cosign-installer) and [`gh-action-sigstore-installer`](https://github.com/sigstore/gh-action-sigstore-python)) to help you easily integrate Sigstore into your workflows. You can learn more about them in our [CI Quickstart]({{< relref "quickstart/quickstart-ci">}})
+Sigstore currently offers two different GitHub Actions ([`cosign-installer`](https://github.com/marketplace/actions/cosign-installer) and [`gh-action-sigstore-python`](https://github.com/sigstore/gh-action-sigstore-python)) to help you easily integrate Sigstore into your workflows. You can learn more about them in our [CI Quickstart]({{< relref "quickstart/quickstart-ci">}})
 
 #### GitLab
 

--- a/content/en/language_clients/python.md
+++ b/content/en/language_clients/python.md
@@ -14,7 +14,8 @@ Full project documentation can be found in the [sigstore-python](https://github.
 * Support for keyless signature generation and verification with Sigstore
 * Support for signing with ["ambient" OpenID Connect identities](https://github.com/sigstore/sigstore-python#signing-with-ambient-credentials)
 * A comprehensive [CLI](https://github.com/sigstore/sigstore-python#usage) and corresponding [importable Python API](https://sigstore.github.io/sigstore-python)
-* An official [GitHub Action](https://github.com/sigstore/gh-action-sigstore-python)
+* An official [GitHub Action](https://github.com/sigstore/gh-action-sigstore-python). See [Sigstore CI Quickstart]({{< relref "quickstart/quickstart-ci">}}) for more information on using the action in a CI system.
+
 
 ## Installation
 
@@ -27,22 +28,6 @@ python -m pip install sigstore
 ```
 
 Optionally, you can install `sigstore` and all its dependencies with [hash-checking mode](https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode) enabled. Learn more about it in the [project documentation](https://github.com/sigstore/sigstore-python#installation).
-
-### GitHub Action Installation
-
-You can install the official sigstore-python [GitHub Action](https://github.com/sigstore/gh-action-sigstore-python) from the
-[GitHub Marketplace](https://github.com/marketplace/actions/gh-action-sigstore-python).
-
-You can also manually add the sigstore-python action to your CI:
-
-```yaml
-jobs:
-  sigstore-python:
-    steps:
-      - uses: sigstore/gh-action-sigstore-python@v3.0.0
-        with:
-          inputs: foo.txt
-```
 
 ## Example
 

--- a/content/en/quickstart/quickstart-ci.md
+++ b/content/en/quickstart/quickstart-ci.md
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
         # This step uses 'gh-action-sigstore-python' to sign the file designated in the inputs field.
-        - uses: sigstore/gh-action-sigstore-python@v3.1.0
+        - uses: sigstore/gh-action-sigstore-python@v3.2.0
           with:
             inputs: to_be_signed.txt
 ```


### PR DESCRIPTION
* current version is 3.2.0
* Remove the example in python.md: quickstart-ci.md seems good enough
* Fix a typo in the action name in oidc-in-fulcio.md
