### PR TITLE
docs(installation): add mise alternative method installation

### DIFF
--- a/content/en/cosign/system_config/installation.md
+++ b/content/en/cosign/system_config/installation.md
@@ -44,6 +44,14 @@ If you are using Homebrew (or Linuxbrew), you can install Cosign by running:
 brew install cosign
 ```
 
+## Mise
+
+If you are using [Mise](https://github.com/jdx/mise), you can install Cosign by running:
+
+```bash
+mise use -g cosign@latest
+```
+
 ## Arch Linux
 
 If you are using Arch Linux, you can install Cosign by running:


### PR DESCRIPTION

#### Summary

Wanted that user know that they can use mise to install sigstore

#### Release Note

NONE

#### Documentation

Only documentation updated here !
