### PR TITLE
Refresh policy-controller installation docs

### DIFF
--- a/content/en/policy-controller/installation.md
+++ b/content/en/policy-controller/installation.md
@@ -10,7 +10,7 @@ The [`policy-controller`](https://github.com/sigstore/policy-controller) is a Ku
 
 ## Prerequisites
 
-- Kubernetes cluster (1.27+)
+- Kubernetes cluster — policy-controller `> 0.10.x` supports Kubernetes 1.27, 1.28, and 1.29; starting with v0.12.0, supported versions are Kubernetes 1.29, 1.30, 1.31, and 1.32. See the [policy-controller support matrix](https://github.com/sigstore/policy-controller#support-policy).
 - [Helm](https://helm.sh/docs/intro/install/) 3.x
 - `kubectl` configured to access your cluster
 
@@ -25,12 +25,7 @@ kubectl create namespace cosign-system
 helm install policy-controller -n cosign-system sigstore/policy-controller
 ```
 
-The chart installs the `ClusterImagePolicy` and `TrustRoot` Custom Resource Definitions (CRDs) automatically. To skip CRD installation (when upgrading and managing CRDs separately):
-
-```bash
-helm install policy-controller -n cosign-system sigstore/policy-controller \
-  --set installCRDs=false
-```
+The chart installs the `ClusterImagePolicy` and `TrustRoot` Custom Resource Definitions (CRDs) automatically.
 
 ## Enable Policy Enforcement for Namespaces
 

--- a/content/en/policy-controller/installation.md
+++ b/content/en/policy-controller/installation.md
@@ -6,28 +6,121 @@ title: Installation
 weight: 905
 ---
 
-The
-[`policy-controller`](https://github.com/sigstore/policy-controller) project contains
-an admission controller for Kubernetes, which can be installed on
-your Kubernetes cluster in a form of a
-[`helm chart`](https://github.com/sigstore/helm-charts/tree/main/charts/policy-controller).
+The [`policy-controller`](https://github.com/sigstore/policy-controller) is a Kubernetes admission controller that enforces image signing policies at deploy time. Install it on your cluster via a [Helm chart](https://github.com/sigstore/helm-charts/tree/main/charts/policy-controller).
 
-If you run a private instance of Sigstore components, you can specify your own
-`TUF` root by mounting your TUF root.json file into the container (for example
-by mounting a Secret) and then pointing to it with --tuf-root argument as well
-as using --tuf-mirror argument to point to where the TUF mirror is. There's
-an optional Secret `tuf-root` that you can create with key `root` that you can
-put the `root.json` file in that gets mounted as `/var/run/tuf/root.json`.
+## Prerequisites
 
-The webhook can be used to automatically validate that all the container images have been signed.
-The webhook also resolves the image tags to ensure the image being ran is not different from when it was admitted.
+- Kubernetes cluster (1.27+)
+- [Helm](https://helm.sh/docs/intro/install/) 3.x
+- `kubectl` configured to access your cluster
 
-The `policy-controller` admission controller will only validate resources in
-namespaces that have chosen to opt-in. See the
-[Enable policy-controller Admission Controller for Namespaces](/policy-controller/overview/#enable-policy-controller-admission-controller-for-namespaces) instructions for more details.
+## Install with Helm
 
-The `policy-controller` resyncs `ClusterImagePolicies` by default every 10 hours.
-Customize the resync period by using the `--policy-resync-period` argument and
-defining a duration for the `policy-webhook` deployment. See the [Golang time package's ParseDuration](https://pkg.go.dev/time#example-ParseDuration) for example duration string formats.
+Add the Sigstore Helm repository and install the chart into the `cosign-system` namespace:
 
-See the [Configuring policy-controller ClusterImagePolicy](/policy-controller/overview/#configuring-policy-controller-clusterimagepolicy) instructions for more details on configuration.
+```bash
+helm repo add sigstore https://sigstore.github.io/helm-charts
+helm repo update
+kubectl create namespace cosign-system
+helm install policy-controller -n cosign-system sigstore/policy-controller
+```
+
+The chart installs the `ClusterImagePolicy` and `TrustRoot` Custom Resource Definitions (CRDs) automatically. To skip CRD installation (when upgrading and managing CRDs separately):
+
+```bash
+helm install policy-controller -n cosign-system sigstore/policy-controller \
+  --set installCRDs=false
+```
+
+## Enable Policy Enforcement for Namespaces
+
+The admission controller validates resources only in namespaces that have opted in. Label the namespaces you want protected:
+
+```bash
+kubectl label namespace my-namespace policy.sigstore.dev/include=true
+```
+
+See [Enable policy-controller Admission Controller for Namespaces](/policy-controller/overview/#enable-policy-controller-admission-controller-for-namespaces).
+
+## Configure Image Validation Behavior
+
+### Unmatched images
+
+Images that do not match any `ClusterImagePolicy` are **denied** by default. Edit the `config-policy-controller` ConfigMap to change this:
+
+```bash
+kubectl patch configmap config-policy-controller -n cosign-system \
+  --type merge \
+  -p '{"data":{"no-match-policy":"warn"}}'
+```
+
+Valid values: `deny` (default), `warn`, `allow`.
+
+### Policy resync period
+
+The controller resyncs `ClusterImagePolicy` resources every 10 hours by default. Adjust this with `--policy-resync-period` on the `policy-webhook` deployment:
+
+```bash
+helm upgrade policy-controller -n cosign-system sigstore/policy-controller \
+  --set webhook.extraArgs.policy-resync-period=2h
+```
+
+See [time.ParseDuration](https://pkg.go.dev/time#example-ParseDuration) for valid duration string formats. The `TrustRoot` resync period defaults to 24 hours and is controlled by `--trustroot-resync-period`.
+
+## Using a Private Sigstore Instance
+
+If you run a private instance of Sigstore components, mount your [TUF (The Update Framework)](https://theupdateframework.io/) `root.json` into the webhook container and point to it at startup.
+
+Create a Secret with your root:
+
+```bash
+kubectl create secret generic tuf-root -n cosign-system \
+  --from-file=root=./root.json
+```
+
+Mount the Secret into the webhook container via your Helm values file:
+
+```yaml
+webhook:
+  volumes:
+    - name: tuf-root
+      secret:
+        secretName: tuf-root
+  volumeMounts:
+    - name: tuf-root
+      mountPath: /var/run/tuf
+      readOnly: true
+```
+
+Then point the webhook at the mounted root:
+
+```bash
+helm upgrade policy-controller -n cosign-system sigstore/policy-controller \
+  -f your-values.yaml \
+  --set webhook.extraArgs.tuf-root=/var/run/tuf/root \
+  --set webhook.extraArgs.tuf-mirror=https://tuf.example.com
+```
+
+To disable TUF entirely (for air-gapped environments or when using only `sigstoreKeys`-based `TrustRoot` resources):
+
+```bash
+helm upgrade policy-controller -n cosign-system sigstore/policy-controller \
+  --set webhook.extraArgs.disable-tuf=true
+```
+
+## Test a Policy Without a Cluster
+
+The `policy-tester` tool validates a `ClusterImagePolicy` against an image locally without a running cluster. Clone the repository and build it:
+
+```bash
+git clone https://github.com/sigstore/policy-controller
+cd policy-controller
+make policy-tester
+./policy-tester --policy=my-policy.yaml --image=ghcr.io/example/app:v1.0.0
+```
+
+## Next Steps
+
+- [Configuring policy-controller ClusterImagePolicy](/policy-controller/overview/#configuring-policy-controller-clusterimagepolicy)
+- [Overview](/policy-controller/overview/)
+


### PR DESCRIPTION
## Summary

Refreshes `content/en/policy-controller/installation.md` (33 → 126 lines) with information that was previously missing or stale.

**New content**
- **Prerequisites section** with the actual upstream Kubernetes support matrix (1.27/28/29 for `> 0.10.x`, 1.29/30/31/32 starting with v0.12.0) and a link to the support policy
- **Namespace opt-in label** — the existing page didn't mention that namespaces have to be labeled `policy.sigstore.dev/include=true`, which is a hard prerequisite users hit immediately
- **Unmatched-image policy** — documents the `no-match-policy` ConfigMap key with the supported values (`deny` default, `warn`, `allow`)
- **Resync periods** for both `ClusterImagePolicy` (10h default) and `TrustRoot` (24h default), with the flags to override
- **Private Sigstore / TUF root mounting** — concrete Helm values + `--tuf-root` / `--tuf-mirror` / `--disable-tuf` flag examples (addresses #67)
- **`policy-tester`** — how to validate a `ClusterImagePolicy` against an image locally without a cluster

**Cross-checked against upstream**
- ConfigMap key (`no-match-policy`) and values: `sigstore/policy-controller` `pkg/config/store.go`
- Webhook flags (`--tuf-root`, `--tuf-mirror`, `--disable-tuf`, `--policy-resync-period`, `--trustroot-resync-period`): `sigstore/policy-controller` `cmd/webhook/main.go`
- `policy-tester` make target: `sigstore/policy-controller` `Makefile`
- Helm chart values + namespace selector default: `sigstore/helm-charts` chart README and `values.yaml`

## Test plan

- [ ] Render the Hugo site locally and confirm the page renders correctly
- [ ] Verify all internal anchor links (`/policy-controller/overview/...`) resolve
- [ ] Verify the support-matrix link to `sigstore/policy-controller#support-policy` resolves
- [ ] Sanity-check the Helm install / upgrade examples on a real cluster

## Notes for reviewers

The Kubernetes prerequisite combines two upstream sources because the README's matrix table hasn't been updated post-v0.12.0 in one place — the table still shows `> 0.10.x → 1.27/28/29`, while the v0.12.0 changelog entry says "drop 1.27/28 and add 1.30/31/32 k8s". The doc cites both. Happy to narrow further if there's a preferred phrasing.

The previous draft of this page recommended `--set installCRDs=false`; that recommendation is dropped here because the chart's CRD templates (`templates/crds/clusterimagepolicy.yaml`, `templates/crds/trustroots.yaml`) install unconditionally and the `installCRDs` value in `values.yaml` is not currently wired to a guard.

Closes #67 (private TUF root mounting documentation gap).