### PR TITLE
Fix duplicated word in Python client docs

### DIFF
--- a/content/en/language_clients/python.md
+++ b/content/en/language_clients/python.md
@@ -33,7 +33,7 @@ Optionally, you can install `sigstore` and all its dependencies with [hash-check
 
 ### Signing example
 
-For this example, we will sign a a file named `foo.txt`. [`sigstore`](https://pypi.org/project/sigstore/) will use OpenID Connect (OIDC) to verify your email address.
+For this example, we will sign a file named `foo.txt`. [`sigstore`](https://pypi.org/project/sigstore/) will use OpenID Connect (OIDC) to verify your email address.
 
 Use the following command to sign `foo.txt`:
 


### PR DESCRIPTION
Removes a duplicated `a` in `content/en/language_clients/python.md`:

`we will sign a a file named` -> `we will sign a file named`