### PR TITLE
docs: remove obsolete COSIGN_EXPERIMENTAL=1 from keyless attest example

### DIFF
--- a/content/en/policy-controller/sample-policies.md
+++ b/content/en/policy-controller/sample-policies.md
@@ -98,8 +98,6 @@ For example purposes, you can use [`sboms/example.spdx.json`](https://github.com
 Then attach the SBOM to your image using [`cosign attest`](https://github.com/sigstore/cosign/blob/main/doc/cosign_attest.md) along with the flag `--type 'https://spdx.dev/Document'`, signing keylessly against the public Fulcio root:
 
 ```
-export COSIGN_EXPERIMENTAL=1
-
 cosign attest --yes --type https://spdx.dev/Document \
   --predicate sboms/example.spdx.json \
   "${IMAGE}"


### PR DESCRIPTION
## Description

The `policy-controller/sample-policies.md` SBOM example sets `export COSIGN_EXPERIMENTAL=1` before a keyless `cosign attest` call. Keyless signing/attestation has been the default since cosign v2, so this variable is no longer required and is misleading for anyone on a current cosign release.

Per the cosign `CHANGELOG.md`:
- `COSIGN_EXPERIMENTAL=1` is no longer required to have identity-based ("keyless") signing and transparency.
- Removing the COSIGN_EXPERIMENTAL environment variable, so the default signing method is now keyless signing with Fulcio.

This removes the stale `export` line; the `cosign attest` command is unchanged and already signs keylessly against the public Fulcio root.

Closes #440.