### PR TITLE
docs: de-duplicate the RPM section in sign-upload.md

### DIFF
--- a/content/en/logging/sign-upload.md
+++ b/content/en/logging/sign-upload.md
@@ -14,7 +14,6 @@ The following are covered:
 - [PKIX/X509](#pkixx509)
 - [RPM](#rpm)
 - [Alpine](#alpine)
-- [RPM](#rpm-1)
 - [TSR](#tsr)
 - [TUF](#tuf)
 
@@ -206,10 +205,6 @@ Body: {
 TODO
 
 ## Alpine
-
-TODO
-
-## RPM
 
 TODO
 


### PR DESCRIPTION
## Description

`content/en/logging/sign-upload.md` listed and rendered the **RPM** section twice: the table of contents had both `[RPM](#rpm)` and `[RPM](#rpm-1)`, backed by two identical `## RPM` headings (with Alpine sandwiched between). This is a copy-paste artifact.

This removes the duplicate `## RPM` heading and its TOC entry, leaving a single RPM section. Purely structural cleanup; no content is added or removed beyond the duplicate stub.

Addresses the duplicate-section part of #441. (The remaining `TODO` placeholders for the pluggable types are out of scope here and left for follow-up.)